### PR TITLE
V1.31.0

### DIFF
--- a/types/consumer-data-standards/admin/index.d.ts
+++ b/types/consumer-data-standards/admin/index.d.ts
@@ -943,7 +943,17 @@ export interface PeakTPSMetricsV2 {
     };
     [k: string]: unknown;
 }
+
+/**
+ * Percentage of calls within the performance threshold for the specified hour. 0.0 means 0%. 1.0 means 100%. Must be a positive value or zero
+ */
+export type PerformanceHours = string;
 /* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
+
+/**
+ * Array of contiguous hourly metrics for the specified day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
+ */
+export type PerformancePreviousDays = string[];
 
 /**
  * Percentage of calls within the performance thresholds
@@ -966,161 +976,159 @@ export interface PerformanceMetrics {
  */
 export interface PerformanceMetricsV3 {
     /**
-     * Percentage of calls within the performance thresholds
+     * Percentage of calls within Primary Data Holder performance thresholds. Note that Secondary Data Holder performance <b>MUST</b> be excluded from this metric.
      */
     aggregate?: {
-        /**
-         * Percentage of calls within the performance threshold for the current day. 0.0 means 0%. 1.0 means 100%. Must be a positive value or zero
-         */
-        currentDay?: string | null;
-        /**
-         * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
-         */
-        previousDays?: string[] | null;
-        [k: string]: unknown;
+      /**
+       * Percentage of calls within the performance threshold for the current day. 0.0 means 0%. 1.0 means 100%. Must be a positive value or zero
+       */
+      currentDay?: string | null;
+      /**
+       * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
+       */
+      previousDays?: string[] | null;
+      [k: string]: unknown;
     } | null;
     /**
      * Percentage of high priority calls within the performance thresholds
      */
     highPriority: {
-        /**
-         * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
-         */
-        currentDay?: string[] | null;
-        /**
-         * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
-         */
-        previousDays?: string[][] | null;
-        [k: string]: unknown;
+      /**
+       * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
+       */
+      currentDay?: string[] | null;
+      /**
+       * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
+       */
+      previousDays?: PerformancePreviousDays[] | null;
+      [k: string]: unknown;
     };
     /**
      * Percentage of large payload calls within the performance thresholds
      */
     largePayload: {
-        /**
-         * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
-         */
-        currentDay?: string[] | null;
-        /**
-         * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
-         */
-        previousDays?: string[][] | null;
-        [k: string]: unknown;
+      /**
+       * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
+       */
+      currentDay?: string[] | null;
+      /**
+       * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
+       */
+      previousDays?: PerformancePreviousDays[] | null;
+      [k: string]: unknown;
     };
     /**
      * Percentage of large Shared Responsibility calls within the performance thresholds. Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
      */
     largeSecondary?: {
+      /**
+       * Percentage of large Shared Responsibility calls within the performance thresholds for the secondary data holder
+       */
+      primary: {
         /**
-         * Percentage of large Shared Responsibility calls within the performance thresholds for the secondary data holder
+         * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
          */
-        primary: {
-            /**
-             * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
-             */
-            currentDay?: string[] | null;
-            /**
-             * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
-             */
-            previousDays?: string[][] | null;
-            [k: string]: unknown;
-        };
+        currentDay?: string[] | null;
         /**
-         * Percentage of large Shared Responsibility calls within the performance thresholds for the secondary data holder
+         * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
          */
-        secondary: {
-            /**
-             * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
-             */
-            currentDay?: string[] | null;
-            /**
-             * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
-             */
-            previousDays?: string[][] | null;
-            [k: string]: unknown;
-        };
+        previousDays?: PerformancePreviousDays[] | null;
         [k: string]: unknown;
+      };
+      /**
+       * Percentage of large Shared Responsibility calls within the performance thresholds for the secondary data holder
+       */
+      secondary: {
+        /**
+         * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
+         */
+        currentDay?: string[] | null;
+        /**
+         * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
+         */
+        previousDays?: PerformancePreviousDays[] | null;
+        [k: string]: unknown;
+      };
+      [k: string]: unknown;
     } | null;
     /**
      * Percentage of low priority calls within the performance thresholds
      */
     lowPriority: {
-        /**
-         * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
-         */
-        currentDay?: string[] | null;
-        /**
-         * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
-         */
-        previousDays?: string[][] | null;
-        [k: string]: unknown;
+      /**
+       * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
+       */
+      currentDay?: string[] | null;
+      /**
+       * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
+       */
+      previousDays?: PerformancePreviousDays[] | null;
+      [k: string]: unknown;
     };
     /**
      * Percentage of Shared Responsibility calls within the performance thresholds. Mandatory for data holders designated for a Shared Responsibility Data Request data cluster
      */
     secondary?: {
+      /**
+       * Percentage of Shared Responsibility calls within the performance thresholds for the primary data holder
+       */
+      primary: {
         /**
-         * Percentage of Shared Responsibility calls within the performance thresholds for the primary data holder
+         * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
          */
-        primary: {
-            /**
-             * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
-             */
-            currentDay?: string[] | null;
-            /**
-             * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
-             */
-            previousDays?: string[][] | null;
-            [k: string]: unknown;
-        };
+        currentDay?: string[] | null;
         /**
-         * Percentage of Shared Responsibility calls within the performance thresholds for the secondary data holder
+         * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
          */
-        secondary: {
-            /**
-             * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
-             */
-            currentDay?: string[] | null;
-            /**
-             * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
-             */
-            previousDays?: string[][] | null;
-            [k: string]: unknown;
-        };
+        previousDays?: PerformancePreviousDays[] | null;
         [k: string]: unknown;
+      };
+      /**
+       * Percentage of Shared Responsibility calls within the performance thresholds for the secondary data holder
+       */
+      secondary: {
+        /**
+         * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
+         */
+        currentDay?: string[] | null;
+        /**
+         * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
+         */
+        previousDays?: PerformancePreviousDays[] | null;
+        [k: string]: unknown;
+      };
+      [k: string]: unknown;
     } | null;
     /**
      * Percentage of unattended calls within the performance thresholds
      */
     unattended: {
-        /**
-         * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
-         */
-        currentDay?: string[] | null;
-        /**
-         * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
-         */
-        previousDays?: string[][] | null;
-        [k: string]: unknown;
+      /**
+       * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
+       */
+      currentDay?: string[] | null;
+      /**
+       * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
+       */
+      previousDays?: PerformancePreviousDays[] | null;
+      [k: string]: unknown;
     };
     /**
      * Percentage of unauthenticated calls within the performance thresholds
      */
     unauthenticated: {
-        /**
-         * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
-         */
-        currentDay?: string[] | null;
-        /**
-         * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
-         */
-        previousDays?: string[][] | null;
-        [k: string]: unknown;
+      /**
+       * Array of contiguous hourly metrics for the current day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
+       */
+      currentDay?: string[] | null;
+      /**
+       * Percentage of calls within the performance threshold for previous days. The first element indicates yesterday and so on. A maximum of seven entries is required if available. 0.0 means 0%. 1.0 means 100%. Values must be a positive or zero
+       */
+      previousDays?: PerformancePreviousDays[] | null;
+      [k: string]: unknown;
     };
     [k: string]: unknown;
-}
-/* These are the schema definitions stipulated by the Data Standards Body for the admin api. */
-
+  }
 /**
  * Number of calls rejected due to traffic thresholds over time
  */

--- a/types/consumer-data-standards/admin/index.d.ts
+++ b/types/consumer-data-standards/admin/index.d.ts
@@ -953,7 +953,7 @@ export type PerformanceHours = string;
 /**
  * Array of contiguous hourly metrics for the specified day.  Each element represents a 1 hour period starting from 12am-1am.  Timezone for determining 12am must be consistent but is at the discretion of the Data Holder
  */
-export type PerformancePreviousDays = string[];
+export type PerformancePreviousDays = PerformanceHours[];
 
 /**
  * Percentage of calls within the performance thresholds

--- a/types/consumer-data-standards/banking/index.d.ts
+++ b/types/consumer-data-standards/banking/index.d.ts
@@ -5,15 +5,15 @@ export interface accV3DetailFeatureObj extends BankingProductFeatureV2 {
 
 export interface BankingAccountDetailV3 extends BankingAccountV2 {
     /**
-     * The unmasked BSB for the account. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
+   * The unmasked BSB for the account. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.
      */
     bsb?: string;
     /**
-     * The unmasked account number for the account. Should not be supplied if the account number is a PAN requiring PCI compliance. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces
+   * The unmasked account number for the account. Should not be supplied if the account number is a PAN requiring PCI compliance. Is expected to be formatted as digits only with leading zeros included and no punctuation or spaces.
      */
     accountNumber?: string;
     /**
-     * Optional field to indicate if this account is part of a bundle that is providing additional benefit for to the customer
+   * Optional field to indicate if this account is part of a bundle that is providing additional benefit to the customer.
      */
     bundleName?: string;
     /**
@@ -24,31 +24,31 @@ export interface BankingAccountDetailV3 extends BankingAccountV2 {
     creditCard?: BankingCreditCardAccount;
     loan?: BankingLoanAccountV2;
     /**
-     * current rate to calculate interest earned being applied to deposit balances as it stands at the time of the API call
+   * current rate to calculate interest earned being applied to deposit balances as it stands at the time of the API call.
      */
     depositRate?: string;
     /**
-     * The current rate to calculate interest payable being applied to lending balances as it stands at the time of the API call
+   * The current rate to calculate interest payable being applied to lending balances as it stands at the time of the API call.
      */
     lendingRate?: string;
     /**
-     * Fully described deposit rates for this account based on the equivalent structure in Product Reference
+   * Fully described deposit rates for this account based on the equivalent structure in Product Reference.
      */
     depositRates?: BankingProductDepositRate[];
     /**
-     * Fully described deposit rates for this account based on the equivalent structure in Product Reference
+   * Fully described lending rates for this account based on the equivalent structure in Product Reference.
      */
     lendingRates?: BankingProductLendingRateV2[];
     /**
-     * Array of features of the account based on the equivalent structure in Product Reference with the following additional field
+   * Array of features of the account based on the equivalent structure in Product Reference with the following additional field.
      */
     features?: accV3DetailFeatureObj[];
     /**
-     * Fees and charges applicable to the account based on the equivalent structure in Product Reference
+   * Fees and charges applicable to the account based on the equivalent structure in Product Reference.
      */
     fees?: BankingProductFee[];
     /**
-     * The addresses for the account to be used for correspondence
+   * The addresses for the account to be used for correspondence.
      */
     addresses?: CommonPhysicalAddress[];
 
@@ -58,39 +58,39 @@ export interface BankingAccountDetailV3 extends BankingAccountV2 {
 
 export interface BankingAccountV2 {
     /**
-     * A unique ID of the account adhering to the standards for ID permanence
+   * A unique ID of the account adhering to the standards for ID permanence.
      */
     accountId: string;
     /**
-     * Value indicating the number of customers that have ownership of the account, according to the data holder's definition of account ownership. Does not indicate that all account owners are eligible consumers
+   * Value indicating the number of customers that have ownership of the account, according to the data holder's definition of account ownership. Does not indicate that all account owners are eligible consumers.
      */
     accountOwnership: "UNKNOWN" | "ONE_PARTY" | "TWO_PARTY" | "MANY_PARTY" | "OTHER";
     /**
-     * Date that the account was created (if known)
+   * Date that the account was created (if known).
      */
     creationDate?: string | null;
     /**
-     * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
+   * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the [MaskedAccountString](#common-field-types) common type.
      */
     displayName: string;
     /**
-     * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
+   * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then `true` is assumed.
      */
     isOwned?: boolean | null;
     /**
-     * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
+   * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number.
      */
     maskedNumber: string;
     /**
-     * A customer supplied nick name for the account
+   * A customer supplied nick name for the account.
      */
     nickname?: string | null;
     /**
-     * Open or closed status for the account. If not present then OPEN is assumed
+   * Open or closed status for the account. If not present then `OPEN` is assumed.
      */
     openStatus?: ("CLOSED" | "OPEN") | null;
     /**
-     * The category to which a product or account belongs. See [here](#product-categories) for more details
+   * The category to which a product or account belongs. See [here](#product-categories) for more details.
      */
     productCategory:
         | "BUSINESS_LOANS"
@@ -106,7 +106,7 @@ export interface BankingAccountV2 {
         | "TRANS_AND_SAVINGS_ACCOUNTS"
         | "TRAVEL_CARDS";
     /**
-     * The unique identifier of the account as defined by the data holder (akin to model number for the account)
+   * The unique identifier of the account as defined by the data holder (akin to model number for the account).
      */
     productName: string;
     [k: string]: unknown;
@@ -116,23 +116,23 @@ export interface BankingAccountV2 {
 
 export interface BankingAuthorisedEntity {
     /**
-     * Australian Business Number for the authorised entity
+   * Australian Business Number for the authorised entity.
      */
     abn?: string | null;
     /**
-     * Australian Company Number for the authorised entity
+   * Australian Company Number for the authorised entity.
      */
     acn?: string | null;
     /**
-     * Australian Registered Body Number for the authorised entity
+   * Australian Registered Body Number for the authorised entity.
      */
     arbn?: string | null;
     /**
-     * Description of the authorised entity derived from previously executed direct debits
+   * Description of the authorised entity derived from previously executed direct debits.
      */
     description?: string | null;
     /**
-     * Name of the financial institution through which the direct debit will be executed. Is required unless the payment is made via a credit card scheme
+   * Name of the financial institution through which the direct debit will be executed. Is required unless the payment is made via a credit card scheme.
      */
     financialInstitution?: string | null;
     [k: string]: unknown;
@@ -141,40 +141,40 @@ export interface BankingAuthorisedEntity {
 
 export interface BankingBalance {
     /**
-     * A unique ID of the account adhering to the standards for ID permanence
+   * A unique ID of the account adhering to the standards for ID permanence.
      */
     accountId: string;
     /**
-     * Object representing the available limit amortised according to payment schedule. Assumed to be zero if absent
+   * Object representing the available limit amortised according to payment schedule. Assumed to be zero if absent.
      */
     amortisedLimit?: string | null;
     /**
-     * Balance representing the amount of funds available for transfer. Assumed to be zero or positive
+   * Balance representing the amount of funds available for transfer. Assumed to be zero or positive.
      */
     availableBalance: string;
     /**
-     * Object representing the maximum amount of credit that is available for this account. Assumed to be zero if absent
+   * Object representing the maximum amount of credit that is available for this account. Assumed to be zero if absent.
      */
     creditLimit?: string | null;
     /**
-     * The currency for the balance amounts. If absent assumed to be AUD
+   * The currency for the balance amounts. If absent assumed to be `AUD`.
      */
     currency?: string | null;
     /**
-     * The balance of the account at this time. Should align to the balance available via other channels such as Internet Banking. Assumed to be negative if the customer has money owing
+   * The balance of the account at this time. Should align to the balance available via other channels such as Internet Banking. Assumed to be negative if the customer has money owing.
      */
     currentBalance: string;
     /**
-     * Optional array of balances for the account in other currencies. Included to support accounts that support multi-currency purses such as Travel Cards
+   * Optional array of balances for the account in other currencies. Included to support accounts that support multi-currency purses such as Travel Cards.
      */
     purses?:
         | Array<{
             /**
-             * The balance available for this additional currency purse
+   * The balance available for this additional currency purse.
              */
             amount: string;
             /**
-             * The currency for the purse
+   * The currency for the purse.
              */
             currency?: string | null;
             [k: string]: unknown;
@@ -186,11 +186,11 @@ export interface BankingBalance {
 
 export interface BankingBalancePurse {
     /**
-     * The balance available for this additional currency purse
+   * The balance available for this additional currency purse.
      */
     amount: string;
     /**
-     * The currency for the purse
+   * The currency for the purse.
      */
     currency?: string | null;
     [k: string]: unknown;
@@ -199,15 +199,15 @@ export interface BankingBalancePurse {
 
 export interface BankingBillerPayee {
     /**
-     * BPAY Biller Code of the Biller
+   * BPAY Biller Code of the Biller.
      */
     billerCode: string;
     /**
-     * Name of the Biller
+   * Name of the Biller.
      */
     billerName: string;
     /**
-     * BPAY CRN of the Biller (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
+   * BPAY CRN of the Biller (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for [MaskedPANString](#common-field-types). If the contents are otherwise sensitive, then it should be masked using the rules applicable for the [MaskedAccountString](#common-field-types) common type.
      */
     crn?: string | null;
     [k: string]: unknown;
@@ -216,19 +216,19 @@ export interface BankingBillerPayee {
 
 export interface BankingCreditCardAccount {
     /**
-     * The minimum payment amount due for the next card payment
+   * The minimum payment amount due for the next card payment.
      */
     minPaymentAmount: string;
     /**
-     * If absent assumes AUD
+   * If absent assumes `AUD`.
      */
     paymentCurrency?: string | null;
     /**
-     * The amount due for the next card payment
+   * The amount due for the next card payment.
      */
     paymentDueAmount: string;
     /**
-     * Date that the next payment for the card is due
+   * Date that the next payment for the card is due.
      */
     paymentDueDate: string;
     [k: string]: unknown;
@@ -237,19 +237,19 @@ export interface BankingCreditCardAccount {
 
 export interface BankingDigitalWalletPayee {
     /**
-     * The identifier of the digital wallet (dependent on type)
+   * The identifier of the digital wallet (dependent on type).
      */
     identifier: string;
     /**
-     * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
+   * The display name of the wallet as given by the customer, else a default value defined by the data holder.
      */
     name: string;
     /**
-     * The provider of the digital wallet
+   * The provider of the digital wallet.
      */
     provider: "PAYPAL_AU" | "OTHER";
     /**
-     * The type of the digital wallet identifier
+   * The type of the digital wallet identifier.
      */
     type: "EMAIL" | "CONTACT_NAME" | "TELEPHONE";
     [k: string]: unknown;
@@ -263,23 +263,23 @@ export interface BankingDirectDebit {
     accountId: string;
     authorisedEntity: {
         /**
-         * Australian Business Number for the authorised entity
+   * Australian Business Number for the authorised entity.
          */
         abn?: string | null;
         /**
-         * Australian Company Number for the authorised entity
+   * Australian Company Number for the authorised entity.
          */
         acn?: string | null;
         /**
-         * Australian Registered Body Number for the authorised entity
+   * Australian Registered Body Number for the authorised entity.
          */
         arbn?: string | null;
         /**
-         * Description of the authorised entity derived from previously executed direct debits
+   * Description of the authorised entity derived from previously executed direct debits.
          */
         description?: string | null;
         /**
-         * Name of the financial institution through which the direct debit will be executed. Is required unless the payment is made via a credit card scheme
+   * Name of the financial institution through which the direct debit will be executed. Is required unless the payment is made via a credit card scheme.
          */
         financialInstitution?: string | null;
         [k: string]: unknown;
@@ -299,37 +299,37 @@ export interface BankingDirectDebit {
 export interface BankingDomesticPayee {
     account?: {
         /**
-         * Name of the account to pay to
+   * Name of the account to pay to.
          */
         accountName?: string | null;
         /**
-         * Number of the account to pay to
+   * Number of the account to pay to.
          */
         accountNumber: string;
         /**
-         * BSB of the account to pay to
+   * BSB of the account to pay to.
          */
         bsb: string;
         [k: string]: unknown;
     };
     card?: {
         /**
-         * Name of the account to pay to
+   * Name of the account to pay to.
          */
         cardNumber: string;
         [k: string]: unknown;
     };
     payId?: {
         /**
-         * The identifier of the PayID (dependent on type)
+   * The identifier of the PayID (dependent on type).
          */
         identifier: string;
         /**
-         * The name assigned to the PayID by the owner of the PayID
+   * The name assigned to the PayID by the owner of the PayID.
          */
         name?: string | null;
         /**
-         * The type of the PayID
+   * The type of the PayID.
          */
         type: "ABN" | "EMAIL" | "ORG_IDENTIFIER" | "TELEPHONE";
         [k: string]: unknown;
@@ -344,15 +344,15 @@ export interface BankingDomesticPayee {
 
 export interface BankingDomesticPayeeAccount {
     /**
-     * Name of the account to pay to
+   * Name of the account to pay to.
      */
     accountName?: string | null;
     /**
-     * Number of the account to pay to
+   * Number of the account to pay to.
      */
     accountNumber: string;
     /**
-     * BSB of the account to pay to
+   * BSB of the account to pay to.
      */
     bsb: string;
     [k: string]: unknown;
@@ -361,7 +361,7 @@ export interface BankingDomesticPayeeAccount {
 
 export interface BankingDomesticPayeeCard {
     /**
-     * Name of the account to pay to
+   * Name of the account to pay to.
      */
     cardNumber: string;
     [k: string]: unknown;
@@ -370,15 +370,15 @@ export interface BankingDomesticPayeeCard {
 
 export interface BankingDomesticPayeePayId {
     /**
-     * The identifier of the PayID (dependent on type)
+   * The identifier of the PayID (dependent on type).
      */
     identifier: string;
     /**
-     * The name assigned to the PayID by the owner of the PayID
+   * The name assigned to the PayID by the owner of the PayID.
      */
     name?: string | null;
     /**
-     * The type of the PayID
+   * The type of the PayID.
      */
     type: "ABN" | "EMAIL" | "ORG_IDENTIFIER" | "TELEPHONE";
     [k: string]: unknown;
@@ -388,61 +388,61 @@ export interface BankingDomesticPayeePayId {
 export interface BankingInternationalPayee {
     bankDetails: {
         /**
-         * Account Targeted for payment
+     * Account Targeted for payment.
          */
         accountNumber: string;
         bankAddress?: {
             /**
-             * Address of the recipient Bank
+       * Address of the recipient Bank.
              */
             address: string;
             /**
-             * Name of the recipient Bank
+       * Name of the recipient Bank.
              */
             name: string;
             [k: string]: unknown;
         } | null;
         /**
-         * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
+     * Swift bank code. Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html).
          */
         beneficiaryBankBIC?: string | null;
         /**
-         * Number for the Clearing House Interbank Payments System
+     * Number for the Clearing House Interbank Payments System.
          */
         chipNumber?: string | null;
         /**
-         * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+     * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code.
          */
         country: string;
         /**
-         * Number for Fedwire payment (Federal Reserve Wire Network)
+     * Number for Fedwire payment (Federal Reserve Wire Network).
          */
         fedWireNumber?: string | null;
         /**
-         * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
+     * The legal entity identifier (LEI) for the beneficiary. Aligns with [ISO 17442](https://www.iso.org/standard/59771.html).
          */
         legalEntityIdentifier?: string | null;
         /**
-         * International bank routing number
+     * International bank routing number.
          */
         routingNumber?: string | null;
         /**
-         * Sort code used for account identification in some jurisdictions
+     * Sort code used for account identification in some jurisdictions.
          */
         sortCode?: string | null;
         [k: string]: unknown;
     };
     beneficiaryDetails: {
         /**
-         * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+     * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code.
          */
         country: string;
         /**
-         * Response message for the payment
+     * Response message for the payment.
          */
         message?: string | null;
         /**
-         * Name of the beneficiary
+     * Name of the beneficiary.
          */
         name?: string | null;
         [k: string]: unknown;
@@ -453,63 +453,63 @@ export interface BankingInternationalPayee {
 
 export interface BankingLoanAccountV2 {
     /**
-     * Date that the loan is due to be repaid in full
+   * Date that the loan is due to be repaid in full.
      */
     loanEndDate?: string | null;
     /**
-     * Maximum amount of funds that can be redrawn. If not present redraw is not available even if the feature exists for the account
+   * Maximum amount of funds that can be redrawn. If not present redraw is not available even if the feature exists for the account.
      */
     maxRedraw?: string | null;
     /**
-     * If absent assumes AUD
+   * If absent assumes `AUD`.
      */
     maxRedrawCurrency?: string | null;
     /**
-     * Minimum amount of next instalment
+   * Minimum amount of next instalment.
      */
     minInstalmentAmount?: string | null;
     /**
-     * If absent assumes AUD
+   * If absent assumes `AUD`.
      */
     minInstalmentCurrency?: string | null;
     /**
-     * Minimum redraw amount
+   * Minimum redraw amount.
      */
     minRedraw?: string | null;
     /**
-     * If absent assumes AUD
+   * If absent assumes `AUD`.
      */
     minRedrawCurrency?: string | null;
     /**
-     * Next date that an instalment is required
+   * Next date that an instalment is required.
      */
     nextInstalmentDate?: string | null;
     /**
-     * Set to true if one or more offset accounts are configured for this loan account
+   * Set to `true` if one or more offset accounts are configured for this loan account.
      */
     offsetAccountEnabled?: boolean | null;
     /**
-     * The accountIDs of the configured offset accounts attached to this loan. Only offset accounts that can be accessed under the current authorisation should be included. It is expected behaviour that offsetAccountEnabled is set to true but the offsetAccountIds field is absent or empty. This represents a situation where an offset account exists but details can not be accessed under the current authorisation
+   * The accountIDs of the configured offset accounts attached to this loan. Only offset accounts that can be accessed under the current authorisation should be included. It is expected behaviour that _offsetAccountEnabled_ is set to `true` but the _offsetAccountIds_ field is absent or empty. This represents a situation where an offset account exists but details can not be accessed under the current authorisation.
      */
     offsetAccountIds?: string[] | null;
     /**
-     * Optional original loan value
+   * Optional original loan value.
      */
     originalLoanAmount?: string | null;
     /**
-     * If absent assumes AUD
+   * If absent assumes `AUD`.
      */
     originalLoanCurrency?: string | null;
     /**
-     * Optional original start date for the loan
+   * Optional original start date for the loan.
      */
     originalStartDate?: string | null;
     /**
-     * The expected or required repayment frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+   * The expected or required repayment frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax).
      */
     repaymentFrequency?: string | null;
     /**
-     * Options in place for repayments. If absent defaults to PRINCIPAL_AND_INTEREST
+   * Options in place for repayments. If absent defaults to `PRINCIPAL_AND_INTEREST`.
      */
     repaymentType?: ("INTEREST_ONLY" | "PRINCIPAL_AND_INTEREST") | null;
     [k: string]: unknown;
@@ -518,20 +518,20 @@ export interface BankingLoanAccountV2 {
 
 export interface BankingPayeeDetailV2 extends BankingPayeeV2 {
     /**
-     * Type of object included that describes the payee in detail
+   * Type of object included that describes the payee in detail.
      */
     payeeUType: "biller" | "digitalWallet" | "domestic" | "international";
     biller?: {
         /**
-         * BPAY Biller Code of the Biller
+   * BPAY Biller Code of the Biller.
          */
         billerCode: string;
         /**
-         * Name of the Biller
+   * Name of the Biller.
          */
         billerName: string;
         /**
-         * BPAY CRN of the Biller (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
+   * BPAY CRN of the Biller (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for [MaskedPANString](#common-field-types). If the contents are otherwise sensitive, then it should be masked using the rules applicable for the [MaskedAccountString](#common-field-types) common type.
          */
         crn?: string | null;
         [k: string]: unknown;
@@ -539,37 +539,37 @@ export interface BankingPayeeDetailV2 extends BankingPayeeV2 {
     domestic?: {
         account?: {
             /**
-             * Name of the account to pay to
+   * Name of the account to pay to.
              */
             accountName?: string | null;
             /**
-             * Number of the account to pay to
+   * Number of the account to pay to.
              */
             accountNumber: string;
             /**
-             * BSB of the account to pay to
+   * BSB of the account to pay to.
              */
             bsb: string;
             [k: string]: unknown;
         };
         card?: {
             /**
-             * Name of the account to pay to
+   * Name of the account to pay to.
              */
             cardNumber: string;
             [k: string]: unknown;
         };
         payId?: {
             /**
-             * The identifier of the PayID (dependent on type)
+   * The identifier of the PayID (dependent on type).
              */
             identifier: string;
             /**
-             * The name assigned to the PayID by the owner of the PayID
+   * The name assigned to the PayID by the owner of the PayID.
              */
             name?: string | null;
             /**
-             * The type of the PayID
+   * The type of the PayID.
              */
             type: "ABN" | "EMAIL" | "ORG_IDENTIFIER" | "TELEPHONE";
             [k: string]: unknown;
@@ -582,19 +582,19 @@ export interface BankingPayeeDetailV2 extends BankingPayeeV2 {
     };
     digitalWallet?: {
         /**
-         * The identifier of the digital wallet (dependent on type)
+   * The identifier of the digital wallet (dependent on type).
          */
         identifier: string;
         /**
-         * The name assigned to the digital wallet by the owner of the wallet, else the display name provided by the digital wallet provider
+   * The display name of the wallet as given by the customer, else a default value defined by the data holder.
          */
         name: string;
         /**
-         * The provider of the digital wallet
+   * The provider of the digital wallet.
          */
         provider: "PAYPAL_AU" | "OTHER";
         /**
-         * The type of the digital wallet identifier
+   * The type of the digital wallet identifier.
          */
         type: "EMAIL" | "CONTACT_NAME" | "TELEPHONE";
         [k: string]: unknown;
@@ -602,61 +602,61 @@ export interface BankingPayeeDetailV2 extends BankingPayeeV2 {
     international?: {
         bankDetails: {
             /**
-             * Account Targeted for payment
+     * Account Targeted for payment.
              */
             accountNumber: string;
             bankAddress?: {
                 /**
-                 * Address of the recipient Bank
+       * Address of the recipient Bank.
                  */
                 address: string;
                 /**
-                 * Name of the recipient Bank
+       * Name of the recipient Bank.
                  */
                 name: string;
                 [k: string]: unknown;
             } | null;
             /**
-             * Swift bank code.  Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html)
+     * Swift bank code. Aligns with standard [ISO 9362](https://www.iso.org/standard/60390.html).
              */
             beneficiaryBankBIC?: string | null;
             /**
-             * Number for the Clearing House Interbank Payments System
+     * Number for the Clearing House Interbank Payments System.
              */
             chipNumber?: string | null;
             /**
-             * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+     * Country of the recipient institution. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code.
              */
             country: string;
             /**
-             * Number for Fedwire payment (Federal Reserve Wire Network)
+     * Number for Fedwire payment (Federal Reserve Wire Network).
              */
             fedWireNumber?: string | null;
             /**
-             * The legal entity identifier (LEI) for the beneficiary.  Aligns with [ISO 17442](https://www.iso.org/standard/59771.html)
+     * The legal entity identifier (LEI) for the beneficiary. Aligns with [ISO 17442](https://www.iso.org/standard/59771.html).
              */
             legalEntityIdentifier?: string | null;
             /**
-             * International bank routing number
+     * International bank routing number.
              */
             routingNumber?: string | null;
             /**
-             * Sort code used for account identification in some jurisdictions
+     * Sort code used for account identification in some jurisdictions.
              */
             sortCode?: string | null;
             [k: string]: unknown;
         };
         beneficiaryDetails: {
             /**
-             * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code
+     * Country where the beneficiary resides. A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code.
              */
             country: string;
             /**
-             * Response message for the payment
+     * Response message for the payment.
              */
             message?: string | null;
             /**
-             * Name of the beneficiary
+     * Name of the beneficiary.
              */
             name?: string | null;
             [k: string]: unknown;
@@ -669,23 +669,23 @@ export interface BankingPayeeDetailV2 extends BankingPayeeV2 {
 
 export interface BankingPayeeV2 {
     /**
-     * The date the payee was created by the customer
+   * The date the payee was created by the customer.
      */
     creationDate?: string | null;
     /**
-     * A description of the payee provided by the customer
+   * A description of the payee provided by the customer.
      */
     description?: string | null;
     /**
-     * The short display name of the payee as provided by the customer. Where a customer has not provided a nickname, a display name derived by the bank for the payee consistent with existing digital banking channels
+   * The short display name of the payee as provided by the customer. Where a customer has not provided a nickname, a display name derived by the bank for the payee consistent with existing digital banking channels.
      */
     nickname: string;
     /**
-     * ID of the payee adhering to the rules of ID permanence
+   * ID of the payee adhering to the rules of ID permanence.
      */
     payeeId: string;
     /**
-     * The type of payee.<br/>DOMESTIC means a registered payee for domestic payments including NPP. <br/>INTERNATIONAL means a registered payee for international payments. <br/>BILLER means a registered payee for BPAY. <br/>DIGITAL_WALLET means a registered payee for a bank's digital wallet
+   * The type of payee.<ul><li>`DOMESTIC` means a registered payee for domestic payments including NPP.<li>`INTERNATIONAL` means a registered payee for international payments.<li>`BILLER` means a registered payee for BPAY.<li>`DIGITAL_WALLET` means a registered payee for a bank's digital wallet.</ul>
      */
     type: "BILLER" | "DIGITAL_WALLET" | "DOMESTIC" | "INTERNATIONAL";
     [k: string]: unknown;
@@ -693,11 +693,11 @@ export interface BankingPayeeV2 {
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 /**
- * Object that contains links to additional information on specific topics
+ * Object that contains links to additional information on specific topics.
  */
 export interface BankingProductAdditionalInformationV2 {
     /**
-     * An array of additional bundles for the product, if applicable. To be treated as secondary documents to the `bundleUri`. Only to be used if there is a primary `bundleUri`.
+   * An array of additional bundles for the product, if applicable. To be treated as secondary documents to the _bundleUri_. Only to be used if there is a primary _bundleUri_.
      */
     additionalBundleUris?:
         | Array<{
@@ -766,11 +766,11 @@ export interface BankingProductAdditionalInformationV2 {
     additionalTermsUris?:
         | Array<{
             /**
-             * The URI describing the additional information
+   * The URI describing the additional information.
              */
             additionalInfoUri: string;
             /**
-             * Display text providing more information about the document URI
+   * Display text providing more information about the document URI.
              */
             description?: string | null;
             [k: string]: unknown;
@@ -802,11 +802,11 @@ export interface BankingProductAdditionalInformationV2 {
 
 export interface BankingProductAdditionalInformationV2AdditionalInformationUris {
     /**
-     * The URI describing the additional information
+   * The URI describing the additional information.
      */
     additionalInfoUri: string;
     /**
-     * Display text providing more information about the document URI
+   * Display text providing more information about the document URI.
      */
     description?: string | null;
     [k: string]: unknown;
@@ -815,23 +815,23 @@ export interface BankingProductAdditionalInformationV2AdditionalInformationUris 
 
 export interface BankingProductBundle {
     /**
-     * Display text providing more information on the bundle
+   * Display text providing more information on the bundle.
      */
     additionalInfo?: string | null;
     /**
-     * Link to a web page with more information on the bundle criteria and benefits
+   * Link to a web page with more information on the bundle criteria and benefits.
      */
     additionalInfoUri?: string | null;
     /**
-     * Description of the bundle
+   * Description of the bundle.
      */
     description: string;
     /**
-     * Name of the bundle
+   * Name of the bundle.
      */
     name: string;
     /**
-     * Array of product IDs for products included in the bundle that are available via the product end points.  Note that this array is not intended to represent a comprehensive model of the products included in the bundle and some products available for the bundle may not be available via the product reference end points
+   * Array of product IDs for products included in the bundle that are available via the product endpoints. Note that this array is not intended to represent a comprehensive model of the products included in the bundle and some products available for the bundle may not be available via the product reference endpoints.
      */
     productIds?: string[] | null;
     [k: string]: unknown;
@@ -839,7 +839,7 @@ export interface BankingProductBundle {
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 /**
- * The category to which a product or account belongs. See [here](#product-categories) for more details
+ * The category to which a product or account belongs. See [here](#product-categories) for more details.
  */
 export type BankingProductCategory =
     | "BUSINESS_LOANS"
@@ -858,19 +858,19 @@ export type BankingProductCategory =
 
 export interface BankingProductConstraint {
     /**
-     * Display text providing more information the constraint
+   * Display text providing more information the constraint.
      */
     additionalInfo?: string | null;
     /**
-     * Link to a web page with more information on the constraint
+   * Link to a web page with more information on the constraint.
      */
     additionalInfoUri?: string | null;
     /**
-     * Generic field containing additional information relevant to the [constraintType](#tocSproductconstrainttypedoc) specified.  Whether mandatory or not is dependent on the value of [constraintType](#tocSproductconstrainttypedoc)
+   * Generic field containing additional information relevant to the [_constraintType_](#tocSproductconstrainttypedoc) specified. Whether mandatory or not is dependent on the value of [_constraintType_](#tocSproductconstrainttypedoc).
      */
     additionalValue?: string | null;
     /**
-     * The type of constraint described.  See the next section for an overview of valid values and their meaning
+   * The type of constraint described. For further details, refer to [Product Constraint Types](#tocSproductconstrainttypedoc).
      */
     constraintType: "MAX_BALANCE" | "MAX_LIMIT" | "MIN_BALANCE" | "MIN_LIMIT" | "OPENING_BALANCE";
     [k: string]: unknown;
@@ -879,35 +879,35 @@ export interface BankingProductConstraint {
 
 export interface BankingProductDepositRate {
     /**
-     * Display text providing more information on the rate
+   * Display text providing more information on the rate.
      */
     additionalInfo?: string | null;
     /**
-     * Link to a web page with more information on this rate
+   * Link to a web page with more information on this rate.
      */
     additionalInfoUri?: string | null;
     /**
-     * Generic field containing additional information relevant to the [depositRateType](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [depositRateType](#tocSproductdepositratetypedoc)
+   * Generic field containing additional information relevant to the [_depositRateType_](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [_depositRateType_](#tocSproductdepositratetypedoc).
      */
     additionalValue?: string | null;
     /**
-     * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+   * The period after which the calculated amount(s) (see _calculationFrequency_) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax).
      */
     applicationFrequency?: string | null;
     /**
-     * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+   * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see _applicationFrequency_). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax).
      */
     calculationFrequency?: string | null;
     /**
-     * The type of rate (base, bonus, etc). See the next section for an overview of valid values and their meaning
+   * The type of rate (`FIXED`, `VARIABLE`, `BONUS`, etc.) For further details, refer to [Product Deposit Rate Types](#tocSproductdepositratetypedoc).
      */
     depositRateType: "BONUS" | "BUNDLE_BONUS" | "FIXED" | "FLOATING" | "INTRODUCTORY" | "MARKET_LINKED" | "VARIABLE";
     /**
-     * The rate to be applied
+   * The rate to be applied.
      */
     rate: string;
     /**
-     * Rate tiers applicable for this rate
+   * Rate tiers applicable for this rate.
      */
     tiers?:
         | Array<{
@@ -920,37 +920,37 @@ export interface BankingProductDepositRate {
              */
             additionalInfoUri?: string | null;
             /**
-             * Defines a condition for the applicability of a tiered rate
+ * Defines the criteria and conditions for which a rate applies.
              */
             applicabilityConditions?: {
                 /**
-                 * Display text providing more information on the condition
+   * Display text providing more information on the rate tier.
                  */
                 additionalInfo?: string | null;
                 /**
-                 * Link to a web page with more information on this condition
+   * Link to a web page with more information on this rate tier.
                  */
                 additionalInfoUri?: string | null;
                 [k: string]: unknown;
             };
             /**
-             * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+   * The number of _unitOfMeasure_ units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g., 1 month) this must be the same as _minimumValue_. Where this is the same as the _minimumValue_ value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
              */
             maximumValue?: number | null;
             /**
-             * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+   * The number of _unitOfMeasure_ units that form the lower bound of the tier. The tier should be inclusive of this value.
              */
             minimumValue: number;
             /**
-             * A display name for the tier
+   * A display name for the tier.
              */
             name: string;
             /**
-             * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+   * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps').
              */
             rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
             /**
-             * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+   * The unit of measure that applies to the _minimumValue_ and _maximumValue_ values e.g.,<ul><li>`DOLLAR` amount.<li>`PERCENT` (in the case of loan-to-value ratio or LVR).<li>Tier term period representing a discrete number of `MONTH`(s) or `DAY`(s) (in the case of term deposit tiers).</ul>
              */
             unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
             [k: string]: unknown;
@@ -966,11 +966,11 @@ export interface BankingProductDetailV4 extends BankingProductV4 {
      */
     bundles?: Array<{
         /**
-         * Display text providing more information on the bundle
+   * Display text providing more information on the condition.
          */
         additionalInfo?: string | null;
         /**
-         * Link to a web page with more information on the bundle criteria and benefits
+   * Link to a web page with more information on this condition.
          */
         additionalInfoUri?: string | null;
         /**
@@ -1039,7 +1039,7 @@ export interface BankingProductDetailV4 extends BankingProductV4 {
         [k: string]: unknown;
     }>;
     /**
-     * Constraints on the application for or operation of the product such as minimum balances or limit thresholds
+   * Constraints on the application for or operation of the product such as minimum balances or limit thresholds.
      */
     constraints?: Array<{
         /**
@@ -1339,31 +1339,31 @@ export interface BankingProductDetailV4 extends BankingProductV4 {
          */
         additionalInfo?: string | null;
         /**
-         * Link to a web page with more information on this rate
+   * Link to a web page with more information on this rate.
          */
         additionalInfoUri?: string | null;
         /**
-         * Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
+   * Generic field containing additional information relevant to the [_lendingRateType_](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [_lendingRateType_](#tocSproductlendingratetypedoc).
          */
         additionalValue?: string | null;
         /**
-         * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+   * The period after which the calculated amount(s) (see _calculationFrequency_) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax).
          */
         applicationFrequency?: string | null;
         /**
-         * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+   * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see _applicationFrequency_). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax).
          */
         calculationFrequency?: string | null;
         /**
-         * A comparison rate equivalent for this rate
+   * A comparison rate equivalent for this rate.
          */
         comparisonRate?: string | null;
         /**
-         * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
+   * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered.
          */
         interestPaymentDue?: ("IN_ADVANCE" | "IN_ARREARS") | null;
         /**
-         * The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
+   * The type of rate (`FIXED`, `VARIABLE`, etc.) For further details, refer to [Product Lending Rate Types](#tocSproductlendingratetypedoc).
          */
         lendingRateType:
             | "BUNDLE_DISCOUNT_FIXED"
@@ -1378,19 +1378,19 @@ export interface BankingProductDetailV4 extends BankingProductV4 {
             | "PURCHASE"
             | "VARIABLE";
         /**
-         * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
+   * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes.
          */
         loanPurpose?: ("INVESTMENT" | "OWNER_OCCUPIED") | null;
         /**
-         * The rate to be applied
+   * The rate to be applied.
          */
         rate: string;
         /**
-         * Options in place for repayments. If absent, the lending rate is applicable to all repayment types
+   * Options in place for repayments. If absent, the lending rate is applicable to all repayment types.
          */
         repaymentType?: ("INTEREST_ONLY" | "PRINCIPAL_AND_INTEREST") | null;
         /**
-         * Rate tiers applicable for this rate
+   * Rate tiers applicable for this rate.
          */
         tiers?:
             | Array<{
@@ -1596,19 +1596,19 @@ export interface BankingProductEligibility {
 
 export interface BankingProductFeatureV2 {
     /**
-     * Display text providing more information on the feature. Mandatory if the [feature type](#tocSproductfeaturetypedoc) is set to OTHER
+   * Display text providing more information on the feature. Mandatory if [_featureType_](#tocSproductfeaturetypedoc) is set to `OTHER`.
      */
     additionalInfo?: string | null;
     /**
-     * Link to a web page with more information on this feature
+   * Link to a web page with more information on this feature.
      */
     additionalInfoUri?: string | null;
     /**
-     * Generic field containing additional information relevant to the [featureType](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [featureType.](#tocSproductfeaturetypedoc)
+   * Generic field containing additional information relevant to the [_featureType_](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [_featureType_](#tocSproductfeaturetypedoc).
      */
     additionalValue?: string | null;
     /**
-     * The type of feature described
+   * The type of feature described. For further details, refer to [Product Feature Types](#tocSproductfeaturetypedoc).
      */
     featureType:
         | "ADDITIONAL_CARDS"
@@ -1646,93 +1646,93 @@ export interface BankingProductFeatureV2 {
 
 export interface BankingProductFee {
     /**
-     * The indicative frequency with which the fee is calculated on the account. Only applies if balanceRate or accruedRate is also present. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+   * The indicative frequency with which the fee is calculated on the account. Only applies if _balanceRate_ or _accruedRate_ is also present. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax).
      */
     accrualFrequency?: string | null;
     /**
-     * A fee rate calculated based on a proportion of the calculated interest accrued on the account. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+   * A fee rate calculated based on a proportion of the calculated interest accrued on the account. One of _amount_, _balanceRate_, _transactionRate_ and _accruedRate_ is mandatory unless the _feeType_ `VARIABLE` is supplied.
      */
     accruedRate?: string | null;
     /**
-     * Display text providing more information on the fee
+   * Display text providing more information on the fee.
      */
     additionalInfo?: string | null;
     /**
-     * Link to a web page with more information on this fee
+   * Link to a web page with more information on this fee.
      */
     additionalInfoUri?: string | null;
     /**
-     * Generic field containing additional information relevant to the [feeType](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [feeType](#tocSproductfeetypedoc)
+   * Generic field containing additional information relevant to the [_feeType_](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [_feeType_](#tocSproductfeetypedoc).
      */
     additionalValue?: string | null;
     /**
-     * The amount charged for the fee. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+   * The amount charged for the fee. One of _amount_, _balanceRate_, _transactionRate_ and _accruedRate_ is mandatory unless the _feeType_ `VARIABLE` is supplied.
      */
     amount?: string | null;
     /**
-     * A fee rate calculated based on a proportion of the balance. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied.
+   * A fee rate calculated based on a proportion of the balance. One of _amount_, _balanceRate_, _transactionRate_ and _accruedRate_ is mandatory unless the _feeType_ `VARIABLE` is supplied.
      */
     balanceRate?: string | null;
     /**
-     * The currency the fee will be charged in. Assumes AUD if absent
+   * The currency the fee will be charged in. Assumes `AUD` if absent.
      */
     currency?: string | null;
     /**
-     * An optional list of discounts to this fee that may be available
+   * An optional list of discounts to this fee that may be available.
      */
     discounts?:
         | Array<{
             /**
-             * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+   * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of _amount_, _balanceRate_, _transactionRate_, _accruedRate_ and _feeRate_ is mandatory. Unless noted in _additionalInfo_, assumes the application and calculation frequency are the same as the corresponding fee.
              */
             accruedRate?: string | null;
             /**
-             * Display text providing more information on the discount
+   * Display text providing more information on the discount.
              */
             additionalInfo?: string | null;
             /**
-             * Link to a web page with more information on this discount
+   * Link to a web page with more information on this discount.
              */
             additionalInfoUri?: string | null;
             /**
-             * Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
+   * Generic field containing additional information relevant to the [_discountType_](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [_discountType_](#tocSproductdiscounttypedoc).
              */
             additionalValue?: string | null;
             /**
-             * Dollar value of the discount. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory.
+   * Dollar value of the discount. One of _amount_, _balanceRate_, _transactionRate_, _accruedRate_ and _feeRate_ is mandatory.
              */
             amount?: string | null;
             /**
-             * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+   * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of _amount_, _balanceRate_, _transactionRate_, _accruedRate_ and _feeRate_ is mandatory. Unless noted in _additionalInfo_, assumes the application and calculation frequency are the same as the corresponding fee.
              */
             balanceRate?: string | null;
             /**
-             * Description of the discount
+   * Description of the discount.
              */
             description: string;
             /**
-             * The type of discount. See the next section for an overview of valid values and their meaning
+   * The type of discount. For further details, refer to [Product Discount Types](#tocSproductdiscounttypedoc).
              */
             discountType: "BALANCE" | "DEPOSITS" | "ELIGIBILITY_ONLY" | "FEE_CAP" | "PAYMENTS";
             /**
-             * Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
+   * Eligibility constraints that apply to this discount. Mandatory if _discountType_ is `ELIGIBILITY_ONLY`.
              */
             eligibility?:
                 | Array<{
                     /**
-                     * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+   * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [_discountEligibilityType_](#tocSproductdiscounteligibilitydoc).
                      */
                     additionalInfo?: string | null;
                     /**
-                     * Link to a web page with more information on this eligibility constraint
+   * Link to a web page with more information on this eligibility constraint.
                      */
                     additionalInfoUri?: string | null;
                     /**
-                     * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+   * Generic field containing additional information relevant to the [_discountEligibilityType_](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [_discountEligibilityType_](#tocSproductdiscounteligibilitydoc).
                      */
                     additionalValue?: string | null;
                     /**
-                     * The type of the specific eligibility constraint for a discount
+   * The type of the specific eligibility constraint for a discount. For further details, refer to [Product Discount Eligibility Types](#tocSproductdiscounteligibilitydoc).
                      */
                     discountEligibilityType:
                         | "BUSINESS"
@@ -1752,11 +1752,11 @@ export interface BankingProductFee {
                 }>
                 | null;
             /**
-             * A discount rate calculated based on a proportion of the fee to which this discount is attached. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+   * A discount rate calculated based on a proportion of the fee to which this discount is attached. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of _amount_, _balanceRate_, _transactionRate_, _accruedRate_ and _feeRate_ is mandatory. Unless noted in _additionalInfo_, assumes the application and calculation frequency are the same as the corresponding fee.
              */
             feeRate?: string | null;
             /**
-             * A discount rate calculated based on a proportion of a transaction. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory
+   * A discount rate calculated based on a proportion of a transaction. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of _amount_, _balanceRate_, _transactionRate_, _accruedRate_ and _feeRate_ is mandatory.
              */
             transactionRate?: string | null;
             [k: string]: unknown;
@@ -1777,11 +1777,11 @@ export interface BankingProductFee {
         | "VARIABLE"
         | "WITHDRAWAL";
     /**
-     * Name of the fee
+   * Name of the fee.
      */
     name: string;
     /**
-     * A fee rate calculated based on a proportion of a transaction. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+   * A fee rate calculated based on a proportion of a transaction. One of _amount_, _balanceRate_, _transactionRate_ and _accruedRate_ is mandatory unless the _feeType_ `VARIABLE` is supplied.
      */
     transactionRate?: string | null;
     [k: string]: unknown;
@@ -1794,31 +1794,31 @@ export interface BankingProductLendingRateV2 {
      */
     additionalInfo?: string | null;
     /**
-     * Link to a web page with more information on this rate
+   * Link to a web page with more information on this rate.
      */
     additionalInfoUri?: string | null;
     /**
-     * Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
+   * Generic field containing additional information relevant to the [_lendingRateType_](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [_lendingRateType_](#tocSproductlendingratetypedoc).
      */
     additionalValue?: string | null;
     /**
-     * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+   * The period after which the calculated amount(s) (see _calculationFrequency_) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax).
      */
     applicationFrequency?: string | null;
     /**
-     * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+   * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see _applicationFrequency_). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax).
      */
     calculationFrequency?: string | null;
     /**
-     * A comparison rate equivalent for this rate
+   * A comparison rate equivalent for this rate.
      */
     comparisonRate?: string | null;
     /**
-     * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
+   * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered.
      */
     interestPaymentDue?: ("IN_ADVANCE" | "IN_ARREARS") | null;
     /**
-     * The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
+   * The type of rate (`FIXED`, `VARIABLE`, etc.) For further details, refer to [Product Lending Rate Types](#tocSproductlendingratetypedoc).
      */
     lendingRateType:
         | "BUNDLE_DISCOUNT_FIXED"
@@ -1833,19 +1833,19 @@ export interface BankingProductLendingRateV2 {
         | "PURCHASE"
         | "VARIABLE";
     /**
-     * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
+   * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes.
      */
     loanPurpose?: ("INVESTMENT" | "OWNER_OCCUPIED") | null;
     /**
-     * The rate to be applied
+   * The rate to be applied.
      */
     rate: string;
     /**
-     * Options in place for repayments. If absent, the lending rate is applicable to all repayment types
+   * Options in place for repayments. If absent, the lending rate is applicable to all repayment types.
      */
     repaymentType?: ("INTEREST_ONLY" | "PRINCIPAL_AND_INTEREST") | null;
     /**
-     * Rate tiers applicable for this rate
+   * Rate tiers applicable for this rate.
      */
     tiers?:
         | Array<{
@@ -1872,23 +1872,23 @@ export interface BankingProductLendingRateV2 {
                 [k: string]: unknown;
             };
             /**
-             * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+   * The number of _unitOfMeasure_ units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g., 1 month) this must be the same as _minimumValue_. Where this is the same as the _minimumValue_ value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
              */
             maximumValue?: number | null;
             /**
-             * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+   * The number of _unitOfMeasure_ units that form the lower bound of the tier. The tier should be inclusive of this value.
              */
             minimumValue: number;
             /**
-             * A display name for the tier
+   * A display name for the tier.
              */
             name: string;
             /**
-             * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+   * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps').
              */
             rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
             /**
-             * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+   * The unit of measure that applies to the _minimumValue_ and _maximumValue_ values e.g.,<ul><li>`DOLLAR` amount.<li>`PERCENT` (in the case of loan-to-value ratio or LVR).<li>Tier term period representing a discrete number of `MONTH`(s) or `DAY`(s) (in the case of term deposit tiers).</ul>
              */
             unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
             [k: string]: unknown;
@@ -1899,15 +1899,15 @@ export interface BankingProductLendingRateV2 {
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 /**
- * Defines a condition for the applicability of a tiered rate
+ * Defines a condition for the applicability of a tiered rate.
  */
 export interface BankingProductRateCondition {
     /**
-     * Display text providing more information on the condition
+   * Display text providing more information on the condition.
      */
     additionalInfo?: string | null;
     /**
-     * Link to a web page with more information on this condition
+   * Link to a web page with more information on this condition.
      */
     additionalInfoUri?: string | null;
     [k: string]: unknown;
@@ -1915,15 +1915,15 @@ export interface BankingProductRateCondition {
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 /**
- * Defines the criteria and conditions for which a rate applies
+ * Defines a condition for the applicability of a tiered rate.
  */
 export interface BankingProductRateTierV3 {
     /**
-     * Display text providing more information on the rate tier.
+   * Display text providing more information on the condition.
      */
     additionalInfo?: string | null;
     /**
-     * Link to a web page with more information on this rate tier
+   * Link to a web page with more information on this condition.
      */
     additionalInfoUri?: string | null;
     /**
@@ -1931,33 +1931,33 @@ export interface BankingProductRateTierV3 {
      */
     applicabilityConditions?: {
         /**
-         * Display text providing more information on the condition
+   * Display text providing more information on the rate tier.
          */
         additionalInfo?: string | null;
         /**
-         * Link to a web page with more information on this condition
+   * Link to a web page with more information on this rate tier.
          */
         additionalInfoUri?: string | null;
         [k: string]: unknown;
     };
     /**
-     * The number of unitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as minimumValue. Where this is the same as the minimumValue value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+   * The number of _unitOfMeasure_ units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g., 1 month) this must be the same as _minimumValue_. Where this is the same as the _minimumValue_ value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
      */
     maximumValue?: number | null;
     /**
-     * The number of unitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+   * The number of _unitOfMeasure_ units that form the lower bound of the tier. The tier should be inclusive of this value.
      */
     minimumValue: number;
     /**
-     * A display name for the tier
+   * A display name for the tier.
      */
     name: string;
     /**
-     * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+   * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps').
      */
     rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
     /**
-     * The unit of measure that applies to the minimumValue and maximumValue values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+   * The unit of measure that applies to the _minimumValue_ and _maximumValue_ values e.g.,<ul><li>`DOLLAR` amount.<li>`PERCENT` (in the case of loan-to-value ratio or LVR).<li>Tier term period representing a discrete number of `MONTH`(s) or `DAY`(s) (in the case of term deposit tiers).</ul>
      */
     unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
     [k: string]: unknown;
@@ -2076,55 +2076,55 @@ export interface BankingProductV4 {
      */
     applicationUri?: string | null;
     /**
-     * A label of the brand for the product. Able to be used for filtering. For data holders with single brands this value is still required
+   * A label of the brand for the product. Able to be used for filtering. For data holders with single brands this value is still required.
      */
     brand: string;
     /**
-     * An optional display name of the brand
+   * An optional display name of the brand.
      */
     brandName?: string | null;
     /**
-     * An array of card art images
+   * An array of card art images.
      */
     cardArt?:
         | Array<{
             /**
-             * URI reference to a PNG, JPG or GIF image with proportions defined by ISO 7810 ID-1 and width no greater than 512 pixels. The URI reference may be a link or url-encoded data URI according to **[[RFC2397]](#nref-RFC2397)**
+         * URI reference to a PNG, JPG or GIF image with proportions defined by ISO 7810 ID-1 and width no greater than 512 pixels. The URI reference may be a link or url-encoded data URI according to **[[RFC2397]](#nref-RFC2397)**.
              */
             imageUri: string;
             /**
-             * Display label for the specific image
+         * Display label for the specific image.
              */
             title?: string;
             [k: string]: unknown;
         }>
         | null;
     /**
-     * A description of the product
+   * A description of the product.
      */
     description: string;
     /**
-     * The date and time from which this product is effective (ie. is available for origination).  Used to enable the articulation of products to the regime before they are available for customers to originate
+   * The date and time from which this product is effective (i.e. is available for origination). Used to enable the articulation of products to the regime before they are available for customers to originate.
      */
     effectiveFrom?: string | null;
     /**
-     * The date and time at which this product will be retired and will no longer be offered.  Used to enable the managed deprecation of products
+   * The date and time at which this product will be retired and will no longer be offered. Used to enable the managed deprecation of products.
      */
     effectiveTo?: string | null;
     /**
-     * Indicates whether the product is specifically tailored to a circumstance.  In this case fees and prices are significantly negotiated depending on context. While all products are open to a degree of tailoring this flag indicates that tailoring is expected and thus that the provision of specific fees and rates is not applicable
+   * Indicates whether the product is specifically tailored to a circumstance. In this case fees and prices are significantly negotiated depending on context. While all products are open to a degree of tailoring this flag indicates that tailoring is expected and thus that the provision of specific fees and rates is not applicable.
      */
     isTailored: boolean;
     /**
-     * The last date and time that the information for this product was changed (or the creation date for the product if it has never been altered)
+   * The last date and time that the information for this product was changed (or the creation date for the product if it has never been altered).
      */
     lastUpdated: string;
     /**
-     * The display name of the product
+   * The display name of the product.
      */
     name: string;
     /**
-     * The category to which a product or account belongs. See [here](#product-categories) for more details
+   * The category to which a product or account belongs. See [here](#product-categories) for more details.
      */
     productCategory:
         | "BUSINESS_LOANS"
@@ -2217,11 +2217,11 @@ export interface BankingScheduledPaymentV2 {
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 /**
- * Object containing details of the source of the payment. Currently only specifies an account ID but provided as an object to facilitate future extensibility and consistency with the to object
+ * Object containing details of the source of the payment. Currently only specifies an account ID but provided as an object to facilitate future extensibility and consistency with the _to_ object.
  */
 export interface BankingScheduledPaymentFrom {
     /**
-     * ID of the account that is the source of funds for the payment
+   * ID of the account that is the source of funds for the payment.
      */
     accountId: string;
     [k: string]: unknown;
@@ -2230,11 +2230,11 @@ export interface BankingScheduledPaymentFrom {
 
 export interface BankingScheduledPaymentInterval {
     /**
-     * Uses an interval to define the ordinal day within the interval defined by the interval field on which the payment occurs. If the resulting duration is 0 days in length or larger than the number of days in the interval then the payment will occur on the last day of the interval. A duration of 1 day indicates the first day of the interval. If absent the assumed value is P1D. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. The first day of a week is considered to be Monday.
+   * Uses an interval to define the ordinal day within the interval defined by the interval field on which the payment occurs. If the resulting duration is 0 days in length or larger than the number of days in the interval then the payment will occur on the last day of the interval. A duration of 1 day indicates the first day of the interval. If absent the assumed value is `P1D`. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. The first day of a week is considered to be Monday.
      */
     dayInInterval?: string | null;
     /**
-     * An interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations)  (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+   * An interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with _nextPaymentDate_.
      */
     interval: string;
     [k: string]: unknown;
@@ -2242,7 +2242,7 @@ export interface BankingScheduledPaymentInterval {
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 /**
- * Object containing the detail of the schedule for the payment
+ * Object containing the detail of the schedule for the payment.
  */
 export interface BankingScheduledPaymentRecurrence {
     /**
@@ -2258,7 +2258,7 @@ export interface BankingScheduledPaymentRecurrence {
      */
     lastWeekDay?: BankingScheduledPaymentRecurrenceLastWeekday;
     /**
-     * The date of the next payment under the recurrence schedule
+   * The date of the next payment under the recurrence schedule.
      */
     nextPaymentDate?: string | null;
     /**
@@ -2266,7 +2266,7 @@ export interface BankingScheduledPaymentRecurrence {
      */
     onceOff?: BankingScheduledPaymentRecurrenceOnceOff;
     /**
-     * The type of recurrence used to define the schedule
+   * The type of recurrence used to define the schedule.
      */
     recurrenceUType: "eventBased" | "intervalSchedule" | "lastWeekDay" | "onceOff";
     [k: string]: unknown;
@@ -2274,11 +2274,11 @@ export interface BankingScheduledPaymentRecurrence {
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 /**
- * Indicates that the schedule of payments is defined according to an external event that cannot be predetermined. Mandatory if recurrenceUType is set to eventBased
+ * Indicates that the schedule of payments is defined according to an external event that cannot be predetermined. Mandatory if _recurrenceUType_ is set to `eventBased`.
  */
 export interface BankingScheduledPaymentRecurrenceEventBased {
     /**
-     * Description of the event and conditions that will result in the payment. Expected to be formatted for display to a customer
+   * Description of the event and conditions that will result in the payment. Expected to be formatted for display to a customer.
      */
     description: string;
     [k: string]: unknown;
@@ -2286,15 +2286,15 @@ export interface BankingScheduledPaymentRecurrenceEventBased {
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 /**
- * Indicates that the schedule of payments is defined by a series of intervals. Mandatory if recurrenceUType is set to intervalSchedule
+ * Indicates that the schedule of payments is defined by a series of intervals. Mandatory if _recurrenceUType_ is set to `intervalSchedule`.
  */
 export interface BankingScheduledPaymentRecurrenceIntervalSchedule {
     /**
-     * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+   * The limit date after which no more payments should be made using this schedule. If both _finalPaymentDate_ and _paymentsRemaining_ are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely.
      */
     finalPaymentDate?: string | null;
     /**
-     * An array of interval objects defining the payment schedule.  Each entry in the array is additive, in that it adds payments to the overall payment schedule.  If multiple intervals result in a payment on the same day then only one payment will be made. Must have at least one entry
+   * An array of interval objects defining the payment schedule. Each entry in the array is additive, in that it adds payments to the overall payment schedule. If multiple intervals result in a payment on the same day then only one payment will be made. Must have at least one entry.
      */
     intervals: Array<{
         /**
@@ -2320,15 +2320,15 @@ export interface BankingScheduledPaymentRecurrenceIntervalSchedule {
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 /**
- * Indicates that the schedule of payments is defined according to the last occurrence of a specific weekday in an interval. Mandatory if recurrenceUType is set to lastWeekDay
+ * Indicates that the schedule of payments is defined according to the last occurrence of a specific weekday in an interval. Mandatory if _recurrenceUType_ is set to `lastWeekDay`.
  */
 export interface BankingScheduledPaymentRecurrenceLastWeekday {
     /**
-     * The limit date after which no more payments should be made using this schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+   * The limit date after which no more payments should be made using this schedule. If both _finalPaymentDate_ and _paymentsRemaining_ are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely.
      */
     finalPaymentDate?: string | null;
     /**
-     * The interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with nextPaymentDate
+   * The interval for the payment. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax) with components less than a day in length ignored. This duration defines the period between payments starting with _nextPaymentDate_.
      */
     interval: string;
     /**
@@ -2336,11 +2336,11 @@ export interface BankingScheduledPaymentRecurrenceLastWeekday {
      */
     lastWeekDay: "FRI" | "MON" | "SAT" | "SUN" | "THU" | "TUE" | "WED";
     /**
-     * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be ON.<br/>**AFTER** - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<br/>**BEFORE** - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<br/>**ON** - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<br/>**ONLY** - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored
+   * Enumerated field giving the treatment where a scheduled payment date is not a business day. If absent assumed to be `ON`.<ul><li>`AFTER` - If a scheduled payment date is a non-business day the payment will be made on the first business day after the scheduled payment date.<li>`BEFORE` - If a scheduled payment date is a non-business day the payment will be made on the first business day before the scheduled payment date.<li>`ON` - If a scheduled payment date is a non-business day the payment will be made on that day regardless.<li>`ONLY` - Payments only occur on business days. If a scheduled payment date is a non-business day the payment will be ignored.</ul>
      */
     nonBusinessDayTreatment?: ("AFTER" | "BEFORE" | "ON" | "ONLY") | null;
     /**
-     * Indicates the number of payments remaining in the schedule. If both finalPaymentDate and paymentsRemaining are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely
+   * Indicates the number of payments remaining in the schedule. If both _finalPaymentDate_ and _paymentsRemaining_ are present then payments will stop according to the most constraining value. If neither field is present the payments will continue indefinitely.
      */
     paymentsRemaining?: number | null;
     [k: string]: unknown;
@@ -2348,11 +2348,11 @@ export interface BankingScheduledPaymentRecurrenceLastWeekday {
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 /**
- * Indicates that the payment is a once off payment on a specific future date. Mandatory if recurrenceUType is set to onceOff
+ * Indicates that the payment is a once off payment on a specific future date. Mandatory if _recurrenceUType_ is set to `onceOff`.
  */
 export interface BankingScheduledPaymentRecurrenceOnceOff {
     /**
-     * The scheduled date for the once off payment
+   * The scheduled date for the once off payment.
      */
     paymentDate: string;
     [k: string]: unknown;
@@ -2360,7 +2360,7 @@ export interface BankingScheduledPaymentRecurrenceOnceOff {
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 /**
- * The set of payment amounts and destination accounts for this payment accommodating multi-part payments. A single entry indicates a simple payment with one destination account. Must have at least one entry
+ * Indicates that the schedule of payments is defined according to an external event that cannot be predetermined. Mandatory if _recurrenceUType_ is set to `eventBased`.
  */
 export interface BankingScheduledPaymentSet {
     /**
@@ -2368,7 +2368,7 @@ export interface BankingScheduledPaymentSet {
      */
     amount?: string | null;
     /**
-     * The currency for the payment. AUD assumed if not present
+     * The currency for the payment. `AUD` assumed if not present
      */
     currency?: string | null;
     /**
@@ -2558,11 +2558,11 @@ export interface BankingScheduledPaymentTo {
 }
 
 /**
- * Object containing details of the destination of the payment. Used to specify a variety of payment destination types
+ * Object containing details of the destination of the payment. Used to specify a variety of payment destination types.
  */
 export interface BankingScheduledPaymentToV2 {
     /**
-     * Present if toUType is set to accountId. Indicates that the payment is to another account that is accessible under the current consent
+   * Present if _toUType_ is set to `accountId`. Indicates that the payment is to another account that is accessible under the current consent.
      */
     accountId?: string | null;
     biller?: {
@@ -2708,11 +2708,11 @@ export interface BankingScheduledPaymentToV2 {
         [k: string]: unknown;
     };
     /**
-     * The short display name of the payee as provided by the customer unless toUType is set to payeeId. Where a customer has not provided a nickname, a display name derived by the bank for payee should be provided that is consistent with existing digital banking channels
+   * The short display name of the payee as provided by the customer unless _toUType_ is set to `payeeId`. Where a customer has not provided a nickname, a display name derived by the bank for payee should be provided that is consistent with existing digital banking channels.
      */
     nickname?: string | null;
     /**
-     * Present if toUType is set to payeeId. Indicates that the payment is to registered payee that can be accessed using the payee end point. If the Bank Payees scope has not been consented to then a payeeId should not be provided and the full payee details should be provided instead
+   * Present if _toUType_ is set to `payeeId`. Indicates that the payment is to registered payee that can be accessed using the payee endpoint. If the Bank Payees scope has not been consented to then a _payeeId_ should not be provided and the full payee details should be provided instead.
      */
     payeeId?: string | null;
     /**
@@ -2729,23 +2729,23 @@ export interface BankingScheduledPaymentToV2 {
 
 export interface BankingTermDepositAccount {
     /**
-     * The lodgement date of the original deposit
+   * The lodgement date of the original deposit.
      */
     lodgementDate: string;
     /**
-     * Amount to be paid upon maturity. If absent it implies the amount to paid is variable and cannot currently be calculated
+   * Amount to be paid upon maturity. If absent it implies the amount to paid is variable and cannot currently be calculated.
      */
     maturityAmount?: string | null;
     /**
-     * If absent assumes AUD
+   * If absent assumes `AUD`.
      */
     maturityCurrency?: string | null;
     /**
-     * Maturity date for the term deposit
+   * Maturity date for the term deposit.
      */
     maturityDate: string;
     /**
-     * Current instructions on action to be taken at maturity. This includes default actions that may be specified in the terms and conditions for the product e.g. roll-over to the same term and frequency of interest payments
+   * Current instructions on action to be taken at maturity. This includes default actions that may be specified in the terms and conditions for the product e.g., roll-over to the same term and frequency of interest payments.
      */
     maturityInstructions: "HOLD_ON_MATURITY" | "PAID_OUT_AT_MATURITY" | "ROLLED_OVER";
     [k: string]: unknown;
@@ -2754,11 +2754,11 @@ export interface BankingTermDepositAccount {
 
 export interface BankingTransaction {
     /**
-     * ID of the account for which transactions are provided
+   * ID of the account for which transactions are provided.
      */
     accountId: string;
     /**
-     * The value of the transaction. Negative values mean money was outgoing from the account
+   * The value of the transaction. Negative values mean money was outgoing from the account.
      */
     amount: string;
     /**
@@ -2766,59 +2766,59 @@ export interface BankingTransaction {
      */
     apcaNumber?: string | null;
     /**
-     * BPAY Biller Code for the transaction (if available)
+   * BPAY Biller Code for the transaction (if available).
      */
     billerCode?: string | null;
     /**
-     * Name of the BPAY biller for the transaction (if available)
+   * Name of the BPAY biller for the transaction (if available).
      */
     billerName?: string | null;
     /**
-     * BPAY CRN for the transaction (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for MaskedPANString. If the contents are are otherwise sensitive, then it should be masked using the rules applicable for the MaskedAccountString common type.
+   * BPAY CRN for the transaction (if available).<br/>Where the CRN contains sensitive information, it should be masked in line with how the Data Holder currently displays account identifiers in their existing online banking channels. If the contents of the CRN match the format of a Credit Card PAN they should be masked according to the rules applicable for [MaskedPANString](#common-field-types). If the contents are otherwise sensitive, then it should be masked using the rules applicable for the [MaskedAccountString](#common-field-types) common type.
      */
     crn?: string | null;
     /**
-     * The currency for the transaction amount. AUD assumed if not present
+   * The currency for the transaction amount. `AUD` assumed if not present.
      */
     currency?: string | null;
     /**
-     * The transaction description as applied by the financial institution
+   * The transaction description as applied by the financial institution.
      */
     description: string;
     /**
-     * The time the transaction was executed by the originating customer, if available
+   * The time the transaction was executed by the originating customer, if available.
      */
     executionDateTime?: string | null;
     /**
-     * True if extended information is available using the transaction detail end point. False if extended data is not available
+   * `true` if extended information is available using the transaction detail endpoint. `false` if extended data is not available.
      */
     isDetailAvailable: boolean;
     /**
-     * The merchant category code (or MCC) for an outgoing payment to a merchant
+   * The merchant category code (or MCC) for an outgoing payment to a merchant.
      */
     merchantCategoryCode?: string | null;
     /**
-     * Name of the merchant for an outgoing payment to a merchant
+   * Name of the merchant for an outgoing payment to a merchant.
      */
     merchantName?: string | null;
     /**
-     * The time the transaction was posted. This field is Mandatory if the transaction has status POSTED.  This is the time that appears on a standard statement
+   * The time the transaction was posted. This field is Mandatory if the transaction has status `POSTED`. This is the time that appears on a standard statement.
      */
     postingDateTime?: string | null;
     /**
-     * The reference for the transaction provided by the originating institution. Empty string if no data provided
+   * The reference for the transaction provided by the originating institution. Empty string if no data provided.
      */
     reference: string;
     /**
-     * Status of the transaction whether pending or posted. Note that there is currently no provision in the standards to guarantee the ability to correlate a pending transaction with an associated posted transaction
+   * Status of the transaction whether pending or posted. Note that there is currently no provision in the standards to guarantee the ability to correlate a pending transaction with an associated posted transaction.
      */
     status: "PENDING" | "POSTED";
     /**
-     * A unique ID of the transaction adhering to the standards for ID permanence.  This is mandatory (through hashing if necessary) unless there are specific and justifiable technical reasons why a transaction cannot be uniquely identified for a particular account type. It is mandatory if `isDetailAvailable` is set to true.
+   * A unique ID of the transaction adhering to the standards for ID permanence. This is mandatory (through hashing if necessary) unless there are specific and justifiable technical reasons why a transaction cannot be uniquely identified for a particular account type. It is mandatory if _isDetailAvailable_ is set to `true`.
      */
     transactionId?: string | null;
     /**
-     * The type of the transaction
+   * The type of the transaction.
      */
     type:
         | "DIRECT_DEBIT"
@@ -2830,7 +2830,7 @@ export interface BankingTransaction {
         | "TRANSFER_INCOMING"
         | "TRANSFER_OUTGOING";
     /**
-     * Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry
+   * Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry.
      */
     valueDateTime?: string | null;
     [k: string]: unknown;
@@ -2840,34 +2840,34 @@ export interface BankingTransaction {
 export interface BankingTransactionDetail extends BankingTransaction {
     extendedData: {
         /**
-         * Label of the originating payer. Mandatory for inbound payment
+     * Label of the originating payer. Mandatory for inbound payment.
          */
         payer?: string;
         /**
-         * Label of the target PayID.  Mandatory for an outbound payment. The name assigned to the BSB/Account Number or PayID (by the owner of the PayID)
+     * Label of the target PayID. Mandatory for an outbound payment. The name assigned to the BSB/Account Number or PayID (by the owner of the PayID).
          */
         payee?: string;
         /**
-         * Optional extended data provided specific to transaction originated via NPP
+     * Optional extended data specific to transactions originated via NPP.
          */
         extensionUType?: "x2p101Payload";
         x2p101Payload?: {
             /**
-             * An extended string description. Only present if specified by the extensionUType field
+       * An extended string description. Required if the _extensionUType_ field is `x2p101Payload`.
              */
             extendedDescription: string;
             /**
-             * An end to end ID for the payment created at initiation
+       * An end to end ID for the payment created at initiation.
              */
             endToEndId?: string;
             /**
-             * Purpose of the payment.  Format is defined by NPP standards for the x2p1.01 overlay service
+       * Purpose of the payment. Format is defined by NPP standards for the x2p1.01 overlay service.
              */
             purposeCode?: string;
             [k: string]: unknown;
         };
         /**
-         * Identifier of the applicable overlay service. Valid values are: X2P1.01
+     * Identifier of the applicable overlay service. Valid values are: `X2P1.01`.
          */
         service: "X2P1.01";
         [k: string]: unknown;
@@ -2877,95 +2877,95 @@ export interface BankingTransactionDetail extends BankingTransaction {
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 /**
- * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
+ * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf).
  */
 export interface CommonPAFAddress {
     /**
-     * Building/Property name 1
+   * Building/Property name 1.
      */
     buildingName1?: string | null;
     /**
-     * Building/Property name 2
+   * Building/Property name 2.
      */
     buildingName2?: string | null;
     /**
-     * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+   * Unique identifier for an address as defined by Australia Post. Also known as Delivery Point Identifier.
      */
     dpid?: string | null;
     /**
-     * Unit number (including suffix, if applicable)
+   * Unit number (including suffix, if applicable).
      */
     flatUnitNumber?: string | null;
     /**
-     * Type of flat or unit for the address
+   * Type of flat or unit for the address.
      */
     flatUnitType?: string | null;
     /**
-     * Floor or level number (including alpha characters)
+   * Floor or level number (including alpha characters).
      */
     floorLevelNumber?: string | null;
     /**
-     * Type of floor or level for the address
+   * Type of floor or level for the address.
      */
     floorLevelType?: string | null;
     /**
-     * Full name of locality
+   * Full name of locality.
      */
     localityName: string;
     /**
-     * Allotment number for the address
+   * Allotment number for the address.
      */
     lotNumber?: string | null;
     /**
-     * Postal delivery number if the address is a postal delivery type
+   * Postal delivery number if the address is a postal delivery type.
      */
     postalDeliveryNumber?: number | null;
     /**
-     * Postal delivery number prefix related to the postal delivery number
+   * Postal delivery number prefix related to the postal delivery number.
      */
     postalDeliveryNumberPrefix?: string | null;
     /**
-     * Postal delivery number suffix related to the postal delivery number
+   * Postal delivery number suffix related to the postal delivery number.
      */
     postalDeliveryNumberSuffix?: string | null;
     /**
-     * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+   * Postal delivery type. (e.g., PO BOX). Valid enumeration defined by Australia Post PAF code file.
      */
     postalDeliveryType?: string | null;
     /**
-     * Postcode for the locality
+   * Postcode for the locality.
      */
     postcode: string;
     /**
-     * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+   * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). `NSW`, `QLD`, `VIC`, `NT`, `WA`, `SA`, `TAS`, `ACT`, `AAT`.
      */
     state: string;
     /**
-     * The name of the street
+   * The name of the street.
      */
     streetName?: string | null;
     /**
-     * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+   * The street type suffix. Valid enumeration defined by Australia Post PAF code file.
      */
     streetSuffix?: string | null;
     /**
-     * The street type. Valid enumeration defined by Australia Post PAF code file
+   * The street type. Valid enumeration defined by Australia Post PAF code file.
      */
     streetType?: string | null;
     /**
-     * Thoroughfare number for a property (first number in a property ranged address)
+   * Thoroughfare number for a property (first number in a property ranged address).
      */
     thoroughfareNumber1?: number | null;
     /**
-     * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+   * Suffix for the thoroughfare number. Only relevant is _thoroughfareNumber1_ is populated.
      */
     thoroughfareNumber1Suffix?: string | null;
     /**
-     * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+   * Second thoroughfare number (only used if the property has a ranged address, e.g., 23-25).
      */
     thoroughfareNumber2?: number | null;
     /**
-     * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+   * Suffix for the second thoroughfare number. Only relevant is _thoroughfareNumber2_ is populated.
      */
     thoroughfareNumber2Suffix?: string | null;
     [k: string]: unknown;
@@ -2974,134 +2974,134 @@ export interface CommonPAFAddress {
 
 export interface CommonPhysicalAddress {
     /**
-     * The type of address object present
+   * The type of address object present.
      */
     addressUType: "paf" | "simple";
     /**
-     * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
+ * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf).
      */
     paf?: {
         /**
-         * Building/Property name 1
+   * Building/Property name 1.
          */
         buildingName1?: string | null;
         /**
-         * Building/Property name 2
+   * Building/Property name 2.
          */
         buildingName2?: string | null;
         /**
-         * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+   * Unique identifier for an address as defined by Australia Post. Also known as Delivery Point Identifier.
          */
         dpid?: string | null;
         /**
-         * Unit number (including suffix, if applicable)
+   * Unit number (including suffix, if applicable).
          */
         flatUnitNumber?: string | null;
         /**
-         * Type of flat or unit for the address
+   * Type of flat or unit for the address.
          */
         flatUnitType?: string | null;
         /**
-         * Floor or level number (including alpha characters)
+   * Floor or level number (including alpha characters).
          */
         floorLevelNumber?: string | null;
         /**
-         * Type of floor or level for the address
+   * Type of floor or level for the address.
          */
         floorLevelType?: string | null;
         /**
-         * Full name of locality
+   * Full name of locality.
          */
         localityName: string;
         /**
-         * Allotment number for the address
+   * Allotment number for the address.
          */
         lotNumber?: string | null;
         /**
-         * Postal delivery number if the address is a postal delivery type
+   * Postal delivery number if the address is a postal delivery type.
          */
         postalDeliveryNumber?: number | null;
         /**
-         * Postal delivery number prefix related to the postal delivery number
+   * Postal delivery number prefix related to the postal delivery number.
          */
         postalDeliveryNumberPrefix?: string | null;
         /**
-         * Postal delivery number suffix related to the postal delivery number
+   * Postal delivery number suffix related to the postal delivery number.
          */
         postalDeliveryNumberSuffix?: string | null;
         /**
-         * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+   * Postal delivery type. (e.g., PO BOX). Valid enumeration defined by Australia Post PAF code file.
          */
         postalDeliveryType?: string | null;
         /**
-         * Postcode for the locality
+   * Postcode for the locality.
          */
         postcode: string;
         /**
-         * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+   * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). `NSW`, `QLD`, `VIC`, `NT`, `WA`, `SA`, `TAS`, `ACT`, `AAT`.
          */
         state: string;
         /**
-         * The name of the street
+   * The name of the street.
          */
         streetName?: string | null;
         /**
-         * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+   * The street type suffix. Valid enumeration defined by Australia Post PAF code file.
          */
         streetSuffix?: string | null;
         /**
-         * The street type. Valid enumeration defined by Australia Post PAF code file
+   * The street type. Valid enumeration defined by Australia Post PAF code file.
          */
         streetType?: string | null;
         /**
-         * Thoroughfare number for a property (first number in a property ranged address)
+   * Thoroughfare number for a property (first number in a property ranged address).
          */
         thoroughfareNumber1?: number | null;
         /**
-         * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+   * Suffix for the thoroughfare number. Only relevant is _thoroughfareNumber1_ is populated.
          */
         thoroughfareNumber1Suffix?: string | null;
         /**
-         * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+   * Second thoroughfare number (only used if the property has a ranged address, e.g., 23-25).
          */
         thoroughfareNumber2?: number | null;
         /**
-         * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+   * Suffix for the second thoroughfare number. Only relevant is _thoroughfareNumber2_ is populated.
          */
         thoroughfareNumber2Suffix?: string | null;
         [k: string]: unknown;
     };
     simple?: {
         /**
-         * First line of the standard address object
+   * First line of the standard address object.
          */
         addressLine1: string;
         /**
-         * Second line of the standard address object
+   * Second line of the standard address object.
          */
         addressLine2?: string | null;
         /**
-         * Third line of the standard address object
+   * Third line of the standard address object.
          */
         addressLine3?: string | null;
         /**
-         * Name of the city or locality
+   * Name of the city or locality.
          */
         city: string;
         /**
-         * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+   * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (`AUS`) is assumed if country is not present.
          */
         country?: string | null;
         /**
-         * Name of the individual or business formatted for inclusion in an address used for physical mail
+   * Name of the individual or business formatted for inclusion in an address used for physical mail.
          */
         mailingName?: string | null;
         /**
-         * Mandatory for Australian addresses
+   * Mandatory for Australian addresses.
          */
         postcode?: string | null;
         /**
-         * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+   * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. `NSW`, `QLD`, `VIC`, `NT`, `WA`, `SA`, `TAS`, `ACT`, `AAT`.
          */
         state: string;
         [k: string]: unknown;
@@ -3112,35 +3112,35 @@ export interface CommonPhysicalAddress {
 
 export interface CommonSimpleAddress {
     /**
-     * First line of the standard address object
+   * First line of the standard address object.
      */
     addressLine1: string;
     /**
-     * Second line of the standard address object
+   * Second line of the standard address object.
      */
     addressLine2?: string | null;
     /**
-     * Third line of the standard address object
+   * Third line of the standard address object.
      */
     addressLine3?: string | null;
     /**
-     * Name of the city or locality
+   * Name of the city or locality.
      */
     city: string;
     /**
-     * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+   * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (`AUS`) is assumed if country is not present.
      */
     country?: string | null;
     /**
-     * Name of the individual or business formatted for inclusion in an address used for physical mail
+   * Name of the individual or business formatted for inclusion in an address used for physical mail.
      */
     mailingName?: string | null;
     /**
-     * Mandatory for Australian addresses
+   * Mandatory for Australian addresses.
      */
     postcode?: string | null;
     /**
-     * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+   * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. `NSW`, `QLD`, `VIC`, `NT`, `WA`, `SA`, `TAS`, `ACT`, `AAT`.
      */
     state: string;
     [k: string]: unknown;
@@ -3149,7 +3149,7 @@ export interface CommonSimpleAddress {
 
 export interface Links {
     /**
-     * Fully qualified link that generated the current response document
+   * Fully qualified link that generated the current response document.
      */
     self: string;
     [k: string]: unknown;
@@ -3158,23 +3158,23 @@ export interface Links {
 
 export interface LinksPaginated {
     /**
-     * URI to the first page of this set. Mandatory if this response is not the first page
+   * URI to the first page of this set. Mandatory if this response is not the first page.
      */
     first?: string | null;
     /**
-     * URI to the last page of this set. Mandatory if this response is not the last page
+   * URI to the last page of this set. Mandatory if this response is not the last page.
      */
     last?: string | null;
     /**
-     * URI to the next page of this set. Mandatory if this response is not the last page
+   * URI to the next page of this set. Mandatory if this response is not the last page.
      */
     next?: string | null;
     /**
-     * URI to the previous page of this set. Mandatory if this response is not the first page
+   * URI to the previous page of this set. Mandatory if this response is not the first page.
      */
     prev?: string | null;
     /**
-     * Fully qualified link that generated the current response document
+   * Fully qualified link that generated the current response document.
      */
     self: string;
     [k: string]: unknown;
@@ -3187,11 +3187,11 @@ export interface Meta {
 /* These are the schema definitions stipulated by the Data Standards Body for the banking api. */
 
 /**
- * Additional data for customised error codes
+ * Additional data for customised error codes.
  */
 export interface MetaError {
     /**
-     * The CDR error code URN which the application-specific error code extends. Mandatory if the error `code` is an application-specific error rather than a standardised error code.
+   * The CDR error code URN which the application-specific error code extends. Mandatory if the error _code_ is an application-specific error rather than a standardised error code.
      */
     urn?: string | null;
     [k: string]: unknown;
@@ -3222,7 +3222,7 @@ export interface MetaPaginatedTransaction {
     totalRecords: number;
     [k: string]: unknown;
     /**
-     * true if "text" query parameter is not supported
+     * `true` if _text_ query parameter is not supported.
      */
     isQueryParamUnsupported?: boolean | null;
 }
@@ -3242,7 +3242,7 @@ export interface RequestAccountIds {
 export interface ResponseBankingAccountByIdV2 {
     data: {
         /**
-         * A unique ID of the account adhering to the standards for ID permanence
+   * A unique ID of the account adhering to the standards for ID permanence.
          */
         accountId: string;
         /**
@@ -3250,27 +3250,27 @@ export interface ResponseBankingAccountByIdV2 {
          */
         creationDate?: string | null;
         /**
-         * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
+   * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the [MaskedAccountString](#common-field-types) common type.
          */
         displayName: string;
         /**
-         * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
+   * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then `true` is assumed.
          */
         isOwned?: boolean | null;
         /**
-         * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
+   * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number.
          */
         maskedNumber: string;
         /**
-         * A customer supplied nick name for the account
+   * A customer supplied nick name for the account.
          */
         nickname?: string | null;
         /**
-         * Open or closed status for the account. If not present then OPEN is assumed
+   * Open or closed status for the account. If not present then `OPEN` is assumed.
          */
         openStatus?: ("CLOSED" | "OPEN") | null;
         /**
-         * The category to which a product or account belongs. See [here](#product-categories) for more details
+   * The category to which a product or account belongs. See [here](#product-categories) for more details.
          */
         productCategory:
             | "BUSINESS_LOANS"
@@ -3286,7 +3286,7 @@ export interface ResponseBankingAccountByIdV2 {
             | "TRANS_AND_SAVINGS_ACCOUNTS"
             | "TRAVEL_CARDS";
         /**
-         * The unique identifier of the account as defined by the data holder (akin to model number for the account)
+   * The unique identifier of the account as defined by the data holder (akin to model number for the account).
          */
         productName: string;
         [k: string]: unknown;
@@ -3309,105 +3309,105 @@ export interface ResponseBankingAccountByIdV2 {
         specificAccountUType?: "creditCard" | "loan" | "termDeposit";
         termDeposit?: Array<{
             /**
-             * The lodgement date of the original deposit
+   * The lodgement date of the original deposit.
              */
             lodgementDate: string;
             /**
-             * Amount to be paid upon maturity. If absent it implies the amount to paid is variable and cannot currently be calculated
+   * Amount to be paid upon maturity. If absent it implies the amount to paid is variable and cannot currently be calculated.
              */
             maturityAmount?: string | null;
             /**
-             * If absent assumes AUD
+   * If absent assumes `AUD`.
              */
             maturityCurrency?: string | null;
             /**
-             * Maturity date for the term deposit
+   * Maturity date for the term deposit.
              */
             maturityDate: string;
             /**
-             * Current instructions on action to be taken at maturity. This includes default actions that may be specified in the terms and conditions for the product e.g. roll-over to the same term and frequency of interest payments
+   * Current instructions on action to be taken at maturity. This includes default actions that may be specified in the terms and conditions for the product e.g., roll-over to the same term and frequency of interest payments.
              */
             maturityInstructions: "HOLD_ON_MATURITY" | "PAID_OUT_AT_MATURITY" | "ROLLED_OVER";
             [k: string]: unknown;
         }>;
         creditCard?: {
             /**
-             * The minimum payment amount due for the next card payment
+   * The minimum payment amount due for the next card payment.
              */
             minPaymentAmount: string;
             /**
-             * If absent assumes AUD
+   * If absent assumes `AUD`.
              */
             paymentCurrency?: string | null;
             /**
-             * The amount due for the next card payment
+   * The amount due for the next card payment.
              */
             paymentDueAmount: string;
             /**
-             * Date that the next payment for the card is due
+   * Date that the next payment for the card is due.
              */
             paymentDueDate: string;
             [k: string]: unknown;
         };
         loan?: {
             /**
-             * Date that the loan is due to be repaid in full
+   * Date that the loan is due to be repaid in full.
              */
             loanEndDate?: string | null;
             /**
-             * Maximum amount of funds that can be redrawn. If not present redraw is not available even if the feature exists for the account
+   * Maximum amount of funds that can be redrawn. If not present redraw is not available even if the feature exists for the account.
              */
             maxRedraw?: string | null;
             /**
-             * If absent assumes AUD
+   * If absent assumes `AUD`.
              */
             maxRedrawCurrency?: string | null;
             /**
-             * Minimum amount of next instalment
+   * Minimum amount of next instalment.
              */
             minInstalmentAmount?: string | null;
             /**
-             * If absent assumes AUD
+   * If absent assumes `AUD`.
              */
             minInstalmentCurrency?: string | null;
             /**
-             * Minimum redraw amount
+   * Minimum redraw amount.
              */
             minRedraw?: string | null;
             /**
-             * If absent assumes AUD
+   * If absent assumes `AUD`.
              */
             minRedrawCurrency?: string | null;
             /**
-             * Next date that an instalment is required
+   * Next date that an instalment is required.
              */
             nextInstalmentDate?: string | null;
             /**
-             * Set to true if one or more offset accounts are configured for this loan account
+   * Set to `true` if one or more offset accounts are configured for this loan account.
              */
             offsetAccountEnabled?: boolean | null;
             /**
-             * The accountIDs of the configured offset accounts attached to this loan. Only offset accounts that can be accessed under the current authorisation should be included. It is expected behaviour that offsetAccountEnabled is set to true but the offsetAccountIds field is absent or empty. This represents a situation where an offset account exists but details can not be accessed under the current authorisation
+   * The accountIDs of the configured offset accounts attached to this loan. Only offset accounts that can be accessed under the current authorisation should be included. It is expected behaviour that _offsetAccountEnabled_ is set to `true` but the _offsetAccountIds_ field is absent or empty. This represents a situation where an offset account exists but details can not be accessed under the current authorisation.
              */
             offsetAccountIds?: string[] | null;
             /**
-             * Optional original loan value
+   * Optional original loan value.
              */
             originalLoanAmount?: string | null;
             /**
-             * If absent assumes AUD
+   * If absent assumes `AUD`.
              */
             originalLoanCurrency?: string | null;
             /**
-             * Optional original start date for the loan
+   * Optional original start date for the loan.
              */
             originalStartDate?: string | null;
             /**
-             * The expected or required repayment frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+   * The expected or required repayment frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax).
              */
             repaymentFrequency?: string | null;
             /**
-             * Options in place for repayments. If absent defaults to PRINCIPAL_AND_INTEREST
+   * Options in place for repayments. If absent defaults to `PRINCIPAL_AND_INTEREST`.
              */
             repaymentType?: ("INTEREST_ONLY" | "PRINCIPAL_AND_INTEREST") | null;
             [k: string]: unknown;
@@ -3425,27 +3425,27 @@ export interface ResponseBankingAccountByIdV2 {
          */
         depositRates?: Array<{
             /**
-             * Display text providing more information on the rate
+   * Display text providing more information on the rate.
              */
             additionalInfo?: string | null;
             /**
-             * Link to a web page with more information on this rate
+   * Link to a web page with more information on this rate.
              */
             additionalInfoUri?: string | null;
             /**
-             * Generic field containing additional information relevant to the [depositRateType](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [depositRateType](#tocSproductdepositratetypedoc)
+   * Generic field containing additional information relevant to the [_depositRateType_](#tocSproductdepositratetypedoc) specified. Whether mandatory or not is dependent on the value of [_depositRateType_](#tocSproductdepositratetypedoc).
              */
             additionalValue?: string | null;
             /**
-             * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+   * The period after which the calculated amount(s) (see _calculationFrequency_) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax).
              */
             applicationFrequency?: string | null;
             /**
-             * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+   * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see _applicationFrequency_). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax).
              */
             calculationFrequency?: string | null;
             /**
-             * The type of rate (base, bonus, etc). See the next section for an overview of valid values and their meaning
+   * The type of rate (`FIXED`, `VARIABLE`, `BONUS`, etc.) For further details, refer to [Product Deposit Rate Types](#tocSproductdepositratetypedoc).
              */
             depositRateType:
                 | "BONUS"
@@ -3456,11 +3456,11 @@ export interface ResponseBankingAccountByIdV2 {
                 | "MARKET_LINKED"
                 | "VARIABLE";
             /**
-             * The rate to be applied
+   * The rate to be applied.
              */
             rate: string;
             /**
-             * Rate tiers applicable for this rate
+   * Rate tiers applicable for this rate.
              */
             tiers?:
                 | Array<{
@@ -3473,37 +3473,37 @@ export interface ResponseBankingAccountByIdV2 {
                      */
                     additionalInfoUri?: string | null;
                     /**
-                     * Defines a condition for the applicability of a tiered rate
+ * Defines the criteria and conditions for which a rate applies.
                      */
                     applicabilityConditions?: {
                         /**
-                         * Display text providing more information on the condition
+   * Display text providing more information on the rate tier.
                          */
                         additionalInfo?: string | null;
                         /**
-                         * Link to a web page with more information on this condition
+   * Link to a web page with more information on this rate tier.
                          */
                         additionalInfoUri?: string | null;
                         [k: string]: unknown;
                     };
                     /**
-                     * The number of tierUnitOfMeasure units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g. 1 month) this must be the same as tierValueMinimum. Where this is the same as the tierValueMinimum value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
+   * The number of _unitOfMeasure_ units that form the upper bound of the tier or band. For a tier with a discrete value (as opposed to a range of values e.g., 1 month) this must be the same as _minimumValue_. Where this is the same as the _minimumValue_ value of the next-higher tier the referenced tier should be exclusive of this value. For example a term deposit of 2 months falls into the upper tier of the following tiers: (1 – 2 months, 2 – 3 months). If absent the tier's range has no upper bound.
                      */
                     maximumValue?: number | null;
                     /**
-                     * The number of tierUnitOfMeasure units that form the lower bound of the tier. The tier should be inclusive of this value
+   * The number of _unitOfMeasure_ units that form the lower bound of the tier. The tier should be inclusive of this value.
                      */
                     minimumValue: number;
                     /**
-                     * A display name for the tier
+   * A display name for the tier.
                      */
                     name: string;
                     /**
-                     * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps')
+   * The method used to calculate the amount to be applied using one or more tiers. A single rate may be applied to the entire balance or each applicable tier rate is applied to the portion of the balance that falls into that tier (referred to as 'bands' or 'steps').
                      */
                     rateApplicationMethod?: ("PER_TIER" | "WHOLE_BALANCE") | null;
                     /**
-                     * The unit of measure that applies to the tierValueMinimum and tierValueMaximum values e.g. a **DOLLAR** amount. **PERCENT** (in the case of loan-to-value ratio or LVR). Tier term period representing a discrete number of **MONTH**'s or **DAY**'s (in the case of term deposit tiers)
+   * The unit of measure that applies to the _minimumValue_ and _maximumValue_ values e.g.,<ul><li>`DOLLAR` amount.<li>`PERCENT` (in the case of loan-to-value ratio or LVR).<li>Tier term period representing a discrete number of `MONTH`(s) or `DAY`(s) (in the case of term deposit tiers).</ul>
                      */
                     unitOfMeasure: "DAY" | "DOLLAR" | "MONTH" | "PERCENT";
                     [k: string]: unknown;
@@ -3520,31 +3520,31 @@ export interface ResponseBankingAccountByIdV2 {
              */
             additionalInfo?: string | null;
             /**
-             * Link to a web page with more information on this rate
+   * Link to a web page with more information on this rate.
              */
             additionalInfoUri?: string | null;
             /**
-             * Generic field containing additional information relevant to the [lendingRateType](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [lendingRateType](#tocSproductlendingratetypedoc)
+   * Generic field containing additional information relevant to the [_lendingRateType_](#tocSproductlendingratetypedoc) specified. Whether mandatory or not is dependent on the value of [_lendingRateType_](#tocSproductlendingratetypedoc).
              */
             additionalValue?: string | null;
             /**
-             * The period after which the calculated amount(s) (see calculationFrequency) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+   * The period after which the calculated amount(s) (see _calculationFrequency_) are 'applied' (i.e. debited or credited) to the account. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax).
              */
             applicationFrequency?: string | null;
             /**
-             * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see applicationFrequency). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+   * The period after which the rate is applied to the balance to calculate the amount due for the period. Calculation of the amount is often daily (as balances may change) but accumulated until the total amount is 'applied' to the account (see _applicationFrequency_). Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax).
              */
             calculationFrequency?: string | null;
             /**
-             * A comparison rate equivalent for this rate
+   * A comparison rate equivalent for this rate.
              */
             comparisonRate?: string | null;
             /**
-             * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered
+   * When loan payments are due to be paid within each period. The investment benefit of earlier payments affect the rate that can be offered.
              */
             interestPaymentDue?: ("IN_ADVANCE" | "IN_ARREARS") | null;
             /**
-             * The type of rate (fixed, variable, etc). See the next section for an overview of valid values and their meaning
+   * The type of rate (`FIXED`, `VARIABLE`, etc.) For further details, refer to [Product Lending Rate Types](#tocSproductlendingratetypedoc).
              */
             lendingRateType:
                 | "BUNDLE_DISCOUNT_FIXED"
@@ -3559,19 +3559,19 @@ export interface ResponseBankingAccountByIdV2 {
                 | "PURCHASE"
                 | "VARIABLE";
             /**
-             * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes
+   * The reason for taking out the loan. If absent, the lending rate is applicable to all loan purposes.
              */
             loanPurpose?: ("INVESTMENT" | "OWNER_OCCUPIED") | null;
             /**
-             * The rate to be applied
+   * The rate to be applied.
              */
             rate: string;
             /**
-             * Options in place for repayments. If absent, the lending rate is applicable to all repayment types
+   * Options in place for repayments. If absent, the lending rate is applicable to all repayment types.
              */
             repaymentType?: ("INTEREST_ONLY" | "PRINCIPAL_AND_INTEREST") | null;
             /**
-             * Rate tiers applicable for this rate
+   * Rate tiers applicable for this rate.
              */
             tiers?:
                 | Array<{
@@ -3628,19 +3628,19 @@ export interface ResponseBankingAccountByIdV2 {
         features?: Array<
             {
                 /**
-                 * Display text providing more information on the feature. Mandatory if the [feature type](#tocSproductfeaturetypedoc) is set to OTHER
+   * Display text providing more information on the feature. Mandatory if [_featureType_](#tocSproductfeaturetypedoc) is set to `OTHER`.
                  */
                 additionalInfo?: string | null;
                 /**
-                 * Link to a web page with more information on this feature
+   * Link to a web page with more information on this feature.
                  */
                 additionalInfoUri?: string | null;
                 /**
-                 * Generic field containing additional information relevant to the [featureType](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [featureType.](#tocSproductfeaturetypedoc)
+   * Generic field containing additional information relevant to the [_featureType_](#tocSproductfeaturetypedoc) specified. Whether mandatory or not is dependent on the value of the [_featureType_](#tocSproductfeaturetypedoc).
                  */
                 additionalValue?: string | null;
                 /**
-                 * The type of feature described
+   * The type of feature described. For further details, refer to [Product Feature Types](#tocSproductfeaturetypedoc).
                  */
                 featureType:
                     | "ADDITIONAL_CARDS"
@@ -3686,93 +3686,93 @@ export interface ResponseBankingAccountByIdV2 {
          */
         fees?: Array<{
             /**
-             * The indicative frequency with which the fee is calculated on the account. Only applies if balanceRate or accruedRate is also present. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+   * The indicative frequency with which the fee is calculated on the account. Only applies if _balanceRate_ or _accruedRate_ is also present. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax).
              */
             accrualFrequency?: string | null;
             /**
-             * A fee rate calculated based on a proportion of the calculated interest accrued on the account. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+   * A fee rate calculated based on a proportion of the calculated interest accrued on the account. One of _amount_, _balanceRate_, _transactionRate_ and _accruedRate_ is mandatory unless the _feeType_ `VARIABLE` is supplied.
              */
             accruedRate?: string | null;
             /**
-             * Display text providing more information on the fee
+   * Display text providing more information on the fee.
              */
             additionalInfo?: string | null;
             /**
-             * Link to a web page with more information on this fee
+   * Link to a web page with more information on this fee.
              */
             additionalInfoUri?: string | null;
             /**
-             * Generic field containing additional information relevant to the [feeType](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [feeType](#tocSproductfeetypedoc)
+   * Generic field containing additional information relevant to the [_feeType_](#tocSproductfeetypedoc) specified. Whether mandatory or not is dependent on the value of [_feeType_](#tocSproductfeetypedoc).
              */
             additionalValue?: string | null;
             /**
-             * The amount charged for the fee. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied
+   * The amount charged for the fee. One of _amount_, _balanceRate_, _transactionRate_ and _accruedRate_ is mandatory unless the _feeType_ `VARIABLE` is supplied.
              */
             amount?: string | null;
             /**
-             * A fee rate calculated based on a proportion of the balance. One of amount, balanceRate, transactionRate and accruedRate is mandatory unless the *feeType* "VARIABLE" is supplied.
+   * A fee rate calculated based on a proportion of the balance. One of _amount_, _balanceRate_, _transactionRate_ and _accruedRate_ is mandatory unless the _feeType_ `VARIABLE` is supplied.
              */
             balanceRate?: string | null;
             /**
-             * The currency the fee will be charged in. Assumes AUD if absent
+   * The currency the fee will be charged in. Assumes `AUD` if absent.
              */
             currency?: string | null;
             /**
-             * An optional list of discounts to this fee that may be available
+   * An optional list of discounts to this fee that may be available.
              */
             discounts?:
                 | Array<{
                     /**
-                     * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+   * A discount rate calculated based on a proportion of the calculated interest accrued on the account. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of _amount_, _balanceRate_, _transactionRate_, _accruedRate_ and _feeRate_ is mandatory. Unless noted in _additionalInfo_, assumes the application and calculation frequency are the same as the corresponding fee.
                      */
                     accruedRate?: string | null;
                     /**
-                     * Display text providing more information on the discount
+   * Display text providing more information on the discount.
                      */
                     additionalInfo?: string | null;
                     /**
-                     * Link to a web page with more information on this discount
+   * Link to a web page with more information on this discount.
                      */
                     additionalInfoUri?: string | null;
                     /**
-                     * Generic field containing additional information relevant to the [discountType](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [discountType](#tocSproductdiscounttypedoc)
+   * Generic field containing additional information relevant to the [_discountType_](#tocSproductdiscounttypedoc) specified. Whether mandatory or not is dependent on the value of [_discountType_](#tocSproductdiscounttypedoc).
                      */
                     additionalValue?: string | null;
                     /**
-                     * Dollar value of the discount. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory.
+   * Dollar value of the discount. One of _amount_, _balanceRate_, _transactionRate_, _accruedRate_ and _feeRate_ is mandatory.
                      */
                     amount?: string | null;
                     /**
-                     * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of amount, balanceRate, transactionRate, accruedRate and feeRate is mandatory. Unless noted in additionalInfo, assumes the application and calculation frequency are the same as the corresponding fee
+   * A discount rate calculated based on a proportion of the balance. Note that the currency of the fee discount is expected to be the same as the currency of the fee itself. One of _amount_, _balanceRate_, _transactionRate_, _accruedRate_ and _feeRate_ is mandatory. Unless noted in _additionalInfo_, assumes the application and calculation frequency are the same as the corresponding fee.
                      */
                     balanceRate?: string | null;
                     /**
-                     * Description of the discount
+   * Description of the discount.
                      */
                     description: string;
                     /**
-                     * The type of discount. See the next section for an overview of valid values and their meaning
+   * The type of discount. For further details, refer to [Product Discount Types](#tocSproductdiscounttypedoc).
                      */
                     discountType: "BALANCE" | "DEPOSITS" | "ELIGIBILITY_ONLY" | "FEE_CAP" | "PAYMENTS";
                     /**
-                     * Eligibility constraints that apply to this discount. Mandatory if ``discountType`` is ``ELIGIBILITY_ONLY``.
+   * Eligibility constraints that apply to this discount. Mandatory if _discountType_ is `ELIGIBILITY_ONLY`.
                      */
                     eligibility?:
                         | Array<{
                             /**
-                             * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+   * Display text providing more information on this eligibility constraint. Whether mandatory or not is dependent on the value of [_discountEligibilityType_](#tocSproductdiscounteligibilitydoc).
                              */
                             additionalInfo?: string | null;
                             /**
-                             * Link to a web page with more information on this eligibility constraint
+   * Link to a web page with more information on this eligibility constraint.
                              */
                             additionalInfoUri?: string | null;
                             /**
-                             * Generic field containing additional information relevant to the [discountEligibilityType](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [discountEligibilityType](#tocSproductdiscounteligibilitydoc)
+   * Generic field containing additional information relevant to the [_discountEligibilityType_](#tocSproductdiscounteligibilitydoc) specified. Whether mandatory or not is dependent on the value of [_discountEligibilityType_](#tocSproductdiscounteligibilitydoc).
                              */
                             additionalValue?: string | null;
                             /**
-                             * The type of the specific eligibility constraint for a discount
+   * The type of the specific eligibility constraint for a discount. For further details, refer to [Product Discount Eligibility Types](#tocSproductdiscounteligibilitydoc).
                              */
                             discountEligibilityType:
                                 | "BUSINESS"
@@ -3831,134 +3831,134 @@ export interface ResponseBankingAccountByIdV2 {
          */
         addresses?: Array<{
             /**
-             * The type of address object present
+   * The type of address object present.
              */
             addressUType: "paf" | "simple";
             /**
-             * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf)
+ * Australian address formatted according to the file format defined by the [PAF file format](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf).
              */
             paf?: {
                 /**
-                 * Building/Property name 1
+   * Building/Property name 1.
                  */
                 buildingName1?: string | null;
                 /**
-                 * Building/Property name 2
+   * Building/Property name 2.
                  */
                 buildingName2?: string | null;
                 /**
-                 * Unique identifier for an address as defined by Australia Post.  Also known as Delivery Point Identifier
+   * Unique identifier for an address as defined by Australia Post. Also known as Delivery Point Identifier.
                  */
                 dpid?: string | null;
                 /**
-                 * Unit number (including suffix, if applicable)
+   * Unit number (including suffix, if applicable).
                  */
                 flatUnitNumber?: string | null;
                 /**
-                 * Type of flat or unit for the address
+   * Type of flat or unit for the address.
                  */
                 flatUnitType?: string | null;
                 /**
-                 * Floor or level number (including alpha characters)
+   * Floor or level number (including alpha characters).
                  */
                 floorLevelNumber?: string | null;
                 /**
-                 * Type of floor or level for the address
+   * Type of floor or level for the address.
                  */
                 floorLevelType?: string | null;
                 /**
-                 * Full name of locality
+   * Full name of locality.
                  */
                 localityName: string;
                 /**
-                 * Allotment number for the address
+   * Allotment number for the address.
                  */
                 lotNumber?: string | null;
                 /**
-                 * Postal delivery number if the address is a postal delivery type
+   * Postal delivery number if the address is a postal delivery type.
                  */
                 postalDeliveryNumber?: number | null;
                 /**
-                 * Postal delivery number prefix related to the postal delivery number
+   * Postal delivery number prefix related to the postal delivery number.
                  */
                 postalDeliveryNumberPrefix?: string | null;
                 /**
-                 * Postal delivery number suffix related to the postal delivery number
+   * Postal delivery number suffix related to the postal delivery number.
                  */
                 postalDeliveryNumberSuffix?: string | null;
                 /**
-                 * Postal delivery type. (eg. PO BOX). Valid enumeration defined by Australia Post PAF code file
+   * Postal delivery type. (e.g., PO BOX). Valid enumeration defined by Australia Post PAF code file.
                  */
                 postalDeliveryType?: string | null;
                 /**
-                 * Postcode for the locality
+   * Postcode for the locality.
                  */
                 postcode: string;
                 /**
-                 * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+   * State in which the address belongs. Valid enumeration defined by Australia Post PAF code file [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf). `NSW`, `QLD`, `VIC`, `NT`, `WA`, `SA`, `TAS`, `ACT`, `AAT`.
                  */
                 state: string;
                 /**
-                 * The name of the street
+   * The name of the street.
                  */
                 streetName?: string | null;
                 /**
-                 * The street type suffix. Valid enumeration defined by Australia Post PAF code file
+   * The street type suffix. Valid enumeration defined by Australia Post PAF code file.
                  */
                 streetSuffix?: string | null;
                 /**
-                 * The street type. Valid enumeration defined by Australia Post PAF code file
+   * The street type. Valid enumeration defined by Australia Post PAF code file.
                  */
                 streetType?: string | null;
                 /**
-                 * Thoroughfare number for a property (first number in a property ranged address)
+   * Thoroughfare number for a property (first number in a property ranged address).
                  */
                 thoroughfareNumber1?: number | null;
                 /**
-                 * Suffix for the thoroughfare number. Only relevant is thoroughfareNumber1 is populated
+   * Suffix for the thoroughfare number. Only relevant is _thoroughfareNumber1_ is populated.
                  */
                 thoroughfareNumber1Suffix?: string | null;
                 /**
-                 * Second thoroughfare number (only used if the property has a ranged address eg 23-25)
+   * Second thoroughfare number (only used if the property has a ranged address, e.g., 23-25).
                  */
                 thoroughfareNumber2?: number | null;
                 /**
-                 * Suffix for the second thoroughfare number. Only relevant is thoroughfareNumber2 is populated
+   * Suffix for the second thoroughfare number. Only relevant is _thoroughfareNumber2_ is populated.
                  */
                 thoroughfareNumber2Suffix?: string | null;
                 [k: string]: unknown;
             };
             simple?: {
                 /**
-                 * First line of the standard address object
+   * First line of the standard address object.
                  */
                 addressLine1: string;
                 /**
-                 * Second line of the standard address object
+   * Second line of the standard address object.
                  */
                 addressLine2?: string | null;
                 /**
-                 * Third line of the standard address object
+   * Third line of the standard address object.
                  */
                 addressLine3?: string | null;
                 /**
-                 * Name of the city or locality
+   * Name of the city or locality.
                  */
                 city: string;
                 /**
-                 * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (AUS) is assumed if country is not present.
+   * A valid [ISO 3166 Alpha-3](https://www.iso.org/iso-3166-country-codes.html) country code. Australia (`AUS`) is assumed if country is not present.
                  */
                 country?: string | null;
                 /**
-                 * Name of the individual or business formatted for inclusion in an address used for physical mail
+   * Name of the individual or business formatted for inclusion in an address used for physical mail.
                  */
                 mailingName?: string | null;
                 /**
-                 * Mandatory for Australian addresses
+   * Mandatory for Australian addresses.
                  */
                 postcode?: string | null;
                 /**
-                 * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. NSW, QLD, VIC, NT, WA, SA, TAS, ACT, AAT
+   * Free text if the country is not Australia. If country is Australia then must be one of the values defined by the [State Type Abbreviation](https://auspost.com.au/content/dam/auspost_corp/media/documents/australia-post-data-guide.pdf) in the PAF file format. `NSW`, `QLD`, `VIC`, `NT`, `WA`, `SA`, `TAS`, `ACT`, `AAT`.
                  */
                 state: string;
                 [k: string]: unknown;
@@ -3969,7 +3969,7 @@ export interface ResponseBankingAccountByIdV2 {
     };
     links: {
         /**
-         * Fully qualified link that generated the current response document
+   * Fully qualified link that generated the current response document.
          */
         self: string;
         [k: string]: unknown;
@@ -3984,39 +3984,39 @@ export interface ResponseBankingAccountByIdV2 {
 export interface ResponseBankingAccountList {
     data: {
         /**
-         * The list of accounts returned. If the filter results in an empty set then this array may have no records
+     * The list of accounts returned. If the filter results in an empty set then this array may have no records.
          */
         accounts: Array<{
             /**
-             * A unique ID of the account adhering to the standards for ID permanence
+   * A unique ID of the account adhering to the standards for ID permanence.
              */
             accountId: string;
             /**
-             * Date that the account was created (if known)
+   * Date that the account was created (if known).
              */
             creationDate?: string | null;
             /**
-             * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the MaskedAccountString common type.
+   * The display name of the account as defined by the bank. This should not incorporate account numbers or PANs. If it does the values should be masked according to the rules of the [MaskedAccountString](#common-field-types) common type.
              */
             displayName: string;
             /**
-             * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then 'true' is assumed
+   * Flag indicating that the customer associated with the authorisation is an owner of the account. Does not indicate sole ownership, however. If not present then `true` is assumed.
              */
             isOwned?: boolean | null;
             /**
-             * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number
+   * A masked version of the account. Whether BSB/Account Number, Credit Card PAN or another number.
              */
             maskedNumber: string;
             /**
-             * A customer supplied nick name for the account
+   * A customer supplied nick name for the account.
              */
             nickname?: string | null;
             /**
-             * Open or closed status for the account. If not present then OPEN is assumed
+   * Open or closed status for the account. If not present then `OPEN` is assumed.
              */
             openStatus?: ("CLOSED" | "OPEN") | null;
             /**
-             * The category to which a product or account belongs. See [here](#product-categories) for more details
+   * The category to which a product or account belongs. See [here](#product-categories) for more details.
              */
             productCategory:
                 | "BUSINESS_LOANS"
@@ -4032,7 +4032,7 @@ export interface ResponseBankingAccountList {
                 | "TRANS_AND_SAVINGS_ACCOUNTS"
                 | "TRAVEL_CARDS";
             /**
-             * The unique identifier of the account as defined by the data holder (akin to model number for the account)
+   * The unique identifier of the account as defined by the data holder (akin to model number for the account).
              */
             productName: string;
             [k: string]: unknown;
@@ -4041,23 +4041,23 @@ export interface ResponseBankingAccountList {
     };
     links: {
         /**
-         * URI to the first page of this set. Mandatory if this response is not the first page
+   * URI to the first page of this set. Mandatory if this response is not the first page.
          */
         first?: string | null;
         /**
-         * URI to the last page of this set. Mandatory if this response is not the last page
+   * URI to the last page of this set. Mandatory if this response is not the last page.
          */
         last?: string | null;
         /**
-         * URI to the next page of this set. Mandatory if this response is not the last page
+   * URI to the next page of this set. Mandatory if this response is not the last page.
          */
         next?: string | null;
         /**
-         * URI to the previous page of this set. Mandatory if this response is not the first page
+   * URI to the previous page of this set. Mandatory if this response is not the first page.
          */
         prev?: string | null;
         /**
-         * Fully qualified link that generated the current response document
+   * Fully qualified link that generated the current response document.
          */
         self: string;
         [k: string]: unknown;
@@ -4113,7 +4113,7 @@ export interface ResponseBankingAccountByIdV3 {
          */
         openStatus?: ("CLOSED" | "OPEN") | null;
         /**
-         * The category to which a product or account belongs. See [here](#product-categories) for more details
+   * The category to which a product or account belongs. See [here](#product-categories) for more details.
          */
         productCategory:
             | "BUSINESS_LOANS"
@@ -4129,7 +4129,7 @@ export interface ResponseBankingAccountByIdV3 {
             | "TRANS_AND_SAVINGS_ACCOUNTS"
             | "TRAVEL_CARDS";
         /**
-         * The unique identifier of the account as defined by the data holder (akin to model number for the account)
+   * A data holder specific unique identifier for this product. This identifier must be unique to a product but does not otherwise need to adhere to ID permanence guidelines.
          */
         productName: string;
         [k: string]: unknown;
@@ -4847,55 +4847,55 @@ export interface ResponseBankingProductByIdV4 {
          */
         applicationUri?: string | null;
         /**
-         * A label of the brand for the product. Able to be used for filtering. For data holders with single brands this value is still required
+   * A label of the brand for the product. Able to be used for filtering. For data holders with single brands this value is still required.
          */
         brand: string;
         /**
-         * An optional display name of the brand
+   * An optional display name of the brand.
          */
         brandName?: string | null;
         /**
-         * An array of card art images
+   * An array of card art images.
          */
         cardArt?:
             | Array<{
                 /**
-                 * URI reference to a PNG, JPG or GIF image with proportions defined by ISO 7810 ID-1 and width no greater than 512 pixels. The URI reference may be a link or url-encoded data URI according to **[[RFC2397]](#nref-RFC2397)**
+         * URI reference to a PNG, JPG or GIF image with proportions defined by ISO 7810 ID-1 and width no greater than 512 pixels. The URI reference may be a link or url-encoded data URI according to **[[RFC2397]](#nref-RFC2397)**.
                  */
                 imageUri: string;
                 /**
-                 * Display label for the specific image
+         * Display label for the specific image.
                  */
                 title?: string;
                 [k: string]: unknown;
             }>
             | null;
         /**
-         * A description of the product
+   * A description of the product.
          */
         description: string;
         /**
-         * The date and time from which this product is effective (ie. is available for origination).  Used to enable the articulation of products to the regime before they are available for customers to originate
+   * The date and time from which this product is effective (i.e. is available for origination). Used to enable the articulation of products to the regime before they are available for customers to originate.
          */
         effectiveFrom?: string | null;
         /**
-         * The date and time at which this product will be retired and will no longer be offered.  Used to enable the managed deprecation of products
+   * The date and time at which this product will be retired and will no longer be offered. Used to enable the managed deprecation of products.
          */
         effectiveTo?: string | null;
         /**
-         * Indicates whether the product is specifically tailored to a circumstance.  In this case fees and prices are significantly negotiated depending on context. While all products are open to a degree of tailoring this flag indicates that tailoring is expected and thus that the provision of specific fees and rates is not applicable
+   * Indicates whether the product is specifically tailored to a circumstance. In this case fees and prices are significantly negotiated depending on context. While all products are open to a degree of tailoring this flag indicates that tailoring is expected and thus that the provision of specific fees and rates is not applicable.
          */
         isTailored: boolean;
         /**
-         * The last date and time that the information for this product was changed (or the creation date for the product if it has never been altered)
+   * The last date and time that the information for this product was changed (or the creation date for the product if it has never been altered).
          */
         lastUpdated: string;
         /**
-         * The display name of the product
+   * The display name of the product.
          */
         name: string;
         /**
-         * The category to which a product or account belongs. See [here](#product-categories) for more details
+   * The category to which a product or account belongs. See [here](#product-categories) for more details.
          */
         productCategory:
             | "BUSINESS_LOANS"
@@ -5419,11 +5419,11 @@ export interface ResponseBankingProductListV2 {
          */
         products: Array<{
             /**
-             * Object that contains links to additional information on specific topics
+ * Object that contains links to additional information on specific topics.
              */
             additionalInformation?: {
                 /**
-                 * An array of additional bundles for the product, if applicable. To be treated as secondary documents to the `bundleUri`. Only to be used if there is a primary `bundleUri`.
+   * An array of additional bundles for the product, if applicable. To be treated as secondary documents to the _bundleUri_. Only to be used if there is a primary _bundleUri_.
                  */
                 additionalBundleUris?:
                     | Array<{
@@ -5439,7 +5439,7 @@ export interface ResponseBankingProductListV2 {
                     }>
                     | null;
                 /**
-                 * An array of additional eligibility rules and criteria for the product, if applicable. To be treated as secondary documents to the `eligibilityUri`. Only to be used if there is a primary `eligibilityUri`.
+   * An array of additional eligibility rules and criteria for the product, if applicable. To be treated as secondary documents to the _eligibilityUri_. Only to be used if there is a primary _eligibilityUri_.
                  */
                 additionalEligibilityUris?:
                     | Array<{
@@ -5455,7 +5455,7 @@ export interface ResponseBankingProductListV2 {
                     }>
                     | null;
                 /**
-                 * An array of additional fees, pricing, discounts, exemptions and bonuses for the product, if applicable. To be treated as secondary documents to the `feesAndPricingUri`. Only to be used if there is a primary `feesAndPricingUri`.
+   * An array of additional fees, pricing, discounts, exemptions and bonuses for the product, if applicable. To be treated as secondary documents to the _feesAndPricingUri_. Only to be used if there is a primary _feesAndPricingUri_.
                  */
                 additionalFeesAndPricingUris?:
                     | Array<{
@@ -5471,7 +5471,7 @@ export interface ResponseBankingProductListV2 {
                     }>
                     | null;
                 /**
-                 * An array of additional general overviews for the product or features of the product, if applicable. To be treated as secondary documents to the `overviewUri`. Only to be used if there is a primary `overviewUri`.
+   * An array of additional general overviews for the product or features of the product, if applicable. To be treated as secondary documents to the _overviewUri_. Only to be used if there is a primary _overviewUri_.
                  */
                 additionalOverviewUris?:
                     | Array<{
@@ -5487,7 +5487,7 @@ export interface ResponseBankingProductListV2 {
                     }>
                     | null;
                 /**
-                 * An array of additional terms and conditions for the product, if applicable. To be treated as secondary documents to the `termsUri`. Only to be used if there is a primary `termsUri`.
+   * An array of additional terms and conditions for the product, if applicable. To be treated as secondary documents to the _termsUri_. Only to be used if there is a primary _termsUri_.
                  */
                 additionalTermsUris?:
                     | Array<{
@@ -5503,23 +5503,23 @@ export interface ResponseBankingProductListV2 {
                     }>
                     | null;
                 /**
-                 * Description of a bundle that this product can be part of. Mandatory if `additionalBundleUris` includes one or more supporting documents.
+   * Description of a bundle that this product can be part of. Mandatory if _additionalBundleUris_ includes one or more supporting documents.
                  */
                 bundleUri?: string | null;
                 /**
-                 * Eligibility rules and criteria for the product. Mandatory if `additionalEligibilityUris` includes one or more supporting documents.
+   * Eligibility rules and criteria for the product. Mandatory if _additionalEligibilityUris_ includes one or more supporting documents.
                  */
                 eligibilityUri?: string | null;
                 /**
-                 * Description of fees, pricing, discounts, exemptions and bonuses for the product. Mandatory if `additionalFeesAndPricingUris` includes one or more supporting documents.
+   * Description of fees, pricing, discounts, exemptions and bonuses for the product. Mandatory if _additionalFeesAndPricingUris_ includes one or more supporting documents.
                  */
                 feesAndPricingUri?: string | null;
                 /**
-                 * General overview of the product. Mandatory if `additionalOverviewUris` includes one or more supporting documents.
+   * General overview of the product. Mandatory if _additionalOverviewUris_ includes one or more supporting documents.
                  */
                 overviewUri?: string | null;
                 /**
-                 * Terms and conditions for the product. Mandatory if `additionalTermsUris` includes one or more supporting documents.
+   * Terms and conditions for the product. Mandatory if _additionalTermsUris_ includes one or more supporting documents.
                  */
                 termsUri?: string | null;
                 [k: string]: unknown;
@@ -5602,23 +5602,23 @@ export interface ResponseBankingProductListV2 {
     };
     links: {
         /**
-         * URI to the first page of this set. Mandatory if this response is not the first page
+   * URI to the first page of this set. Mandatory if this response is not the first page.
          */
         first?: string | null;
         /**
-         * URI to the last page of this set. Mandatory if this response is not the last page
+   * URI to the last page of this set. Mandatory if this response is not the last page.
          */
         last?: string | null;
         /**
-         * URI to the next page of this set. Mandatory if this response is not the last page
+   * URI to the next page of this set. Mandatory if this response is not the last page.
          */
         next?: string | null;
         /**
-         * URI to the previous page of this set. Mandatory if this response is not the first page
+   * URI to the previous page of this set. Mandatory if this response is not the first page.
          */
         prev?: string | null;
         /**
-         * Fully qualified link that generated the current response document
+   * Fully qualified link that generated the current response document.
          */
         self: string;
         [k: string]: unknown;
@@ -5641,7 +5641,7 @@ export interface ResponseBankingProductListV2 {
 export interface ResponseBankingScheduledPaymentsListV2 {
     data: {
         /**
-         * The list of scheduled payments to return
+     * The list of scheduled payments to return.
          */
         scheduledPayments: Array<{
             /**
@@ -5655,15 +5655,15 @@ export interface ResponseBankingScheduledPaymentsListV2 {
                 [k: string]: unknown;
             };
             /**
-             * The short display name of the scheduled payment as provided by the customer if provided. Where a customer has not provided a nickname, a display name derived by the bank for the scheduled payment should be provided that is consistent with existing digital banking channels
+   * The short display name of the scheduled payment as provided by the customer if provided. Where a customer has not provided a nickname, a display name derived by the bank for the scheduled payment should be provided that is consistent with existing digital banking channels.
              */
             nickname?: string | null;
             /**
-             * The reference for the transaction, if applicable, that will be provided by the originating institution for all payments in the payment set. Empty string if no data provided
+   * The reference for the transaction, if applicable, that will be provided by the originating institution for all payments in the payment set. Empty string if no data provided.
              */
             payeeReference?: string | null;
             /**
-             * The reference for the transaction that will be used by the originating institution for the purposes of constructing a statement narrative on the payer’s account. Empty string if no data provided
+   * The reference for the transaction that will be used by the originating institution for the purposes of constructing a statement narrative on the payer’s account. Empty string if no data provided.
              */
             payerReference: string;
             paymentSet: Array<{
@@ -5830,11 +5830,11 @@ export interface ResponseBankingScheduledPaymentsListV2 {
                         [k: string]: unknown;
                     };
                     /**
-                     * The short display name of the payee as provided by the customer unless toUType is set to payeeId. Where a customer has not provided a nickname, a display name derived by the bank for payee should be provided that is consistent with existing digital banking channels
+   * The short display name of the payee as provided by the customer unless _toUType_ is set to `payeeId`. Where a customer has not provided a nickname, a display name derived by the bank for payee should be provided that is consistent with existing digital banking channels.
                      */
                     nickname?: string | null;
                     /**
-                     * Present if toUType is set to payeeId. Indicates that the payment is to registered payee that can be accessed using the payee end point. If the Bank Payees scope has not been consented to then a payeeId should not be provided and the full payee details should be provided instead
+   * Present if _toUType_ is set to `payeeId`. Indicates that the payment is to registered payee that can be accessed using the payee endpoint. If the Bank Payees scope has not been consented to then a _payeeId_ should not be provided and the full payee details should be provided instead.
                      */
                     payeeId?: string | null;
                     /**
@@ -5844,7 +5844,7 @@ export interface ResponseBankingScheduledPaymentsListV2 {
                     /**
                      * The type of object provided that specifies the destination of the funds for the payment.
                      */
-                    toUType: "accountId" | "biller" | "domestic" | "international" | "payeeId";
+  toUType: "accountId" | "biller" | "digitalWallet" | "domestic" | "international" | "payeeId";
                     [k: string]: unknown;
                 };
                 [k: string]: unknown;
@@ -5955,23 +5955,23 @@ export interface ResponseBankingScheduledPaymentsListV2 {
     };
     links: {
         /**
-         * URI to the first page of this set. Mandatory if this response is not the first page
+   * URI to the first page of this set. Mandatory if this response is not the first page.
          */
         first?: string | null;
         /**
-         * URI to the last page of this set. Mandatory if this response is not the last page
+   * URI to the last page of this set. Mandatory if this response is not the last page.
          */
         last?: string | null;
         /**
-         * URI to the next page of this set. Mandatory if this response is not the last page
+   * URI to the next page of this set. Mandatory if this response is not the last page.
          */
         next?: string | null;
         /**
-         * URI to the previous page of this set. Mandatory if this response is not the first page
+   * URI to the previous page of this set. Mandatory if this response is not the first page.
          */
         prev?: string | null;
         /**
-         * Fully qualified link that generated the current response document
+   * Fully qualified link that generated the current response document.
          */
         self: string;
         [k: string]: unknown;
@@ -6290,23 +6290,23 @@ export interface ResponseBankingScheduledPaymentsList {
     };
     links: {
         /**
-         * URI to the first page of this set. Mandatory if this response is not the first page
+   * URI to the first page of this set. Mandatory if this response is not the first page.
          */
         first?: string | null;
         /**
-         * URI to the last page of this set. Mandatory if this response is not the last page
+   * URI to the last page of this set. Mandatory if this response is not the last page.
          */
         last?: string | null;
         /**
-         * URI to the next page of this set. Mandatory if this response is not the last page
+   * URI to the next page of this set. Mandatory if this response is not the last page.
          */
         next?: string | null;
         /**
-         * URI to the previous page of this set. Mandatory if this response is not the first page
+   * URI to the previous page of this set. Mandatory if this response is not the first page.
          */
         prev?: string | null;
         /**
-         * Fully qualified link that generated the current response document
+   * Fully qualified link that generated the current response document.
          */
         self: string;
         [k: string]: unknown;
@@ -6549,23 +6549,23 @@ export interface ResponseBankingTransactionList {
     };
     links: {
         /**
-         * URI to the first page of this set. Mandatory if this response is not the first page
+   * URI to the first page of this set. Mandatory if this response is not the first page.
          */
         first?: string | null;
         /**
-         * URI to the last page of this set. Mandatory if this response is not the last page
+   * URI to the last page of this set. Mandatory if this response is not the last page.
          */
         last?: string | null;
         /**
-         * URI to the next page of this set. Mandatory if this response is not the last page
+   * URI to the next page of this set. Mandatory if this response is not the last page.
          */
         next?: string | null;
         /**
-         * URI to the previous page of this set. Mandatory if this response is not the first page
+   * URI to the previous page of this set. Mandatory if this response is not the first page.
          */
         prev?: string | null;
         /**
-         * Fully qualified link that generated the current response document
+   * Fully qualified link that generated the current response document.
          */
         self: string;
         [k: string]: unknown;

--- a/types/consumer-data-standards/energy/index.d.ts
+++ b/types/consumer-data-standards/energy/index.d.ts
@@ -1853,12 +1853,11 @@ export interface EnergyAccountDetailV3 extends EnergyAccountBaseV2 {
     [k: string]: unknown;
 }
 
-
 export interface EnergyAccountDetailV4 extends EnergyAccountBaseV2 {
     /**
      * The array of plans containing service points and associated plan details
      */
-    plans: {
+    plans: Array<{
       /**
        * Optional display name for the plan provided by the customer to help differentiate multiple plans
        */
@@ -1893,7 +1892,7 @@ export interface EnergyAccountDetailV4 extends EnergyAccountBaseV2 {
       /**
        * An array of additional contacts that are authorised to act on this account
        */
-      authorisedContacts?: {
+      authorisedContacts?: Array<{
         /**
          * For people with single names this field need not be present. The single name should be in the lastName field
          */
@@ -1914,9 +1913,9 @@ export interface EnergyAccountDetailV4 extends EnergyAccountBaseV2 {
          * Used for a trailing suffix to the name (e.g. Jr)
          */
         suffix?: string;
-      }[];
-    }[];
-  };
+      }>;
+    }>;
+}
 
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
@@ -4151,7 +4150,7 @@ export interface EnergyPlanContractV3 {
     /**
      * Payment options for this contract
      */
-    paymentOption: ("PAPER_BILL" | "CREDIT_CARD" | "DIRECT_DEBIT" | "BPAY" | "OTHER")[];
+    paymentOption: Array<("PAPER_BILL" | "CREDIT_CARD" | "DIRECT_DEBIT" | "BPAY" | "OTHER")>;
     /**
      * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
      */
@@ -4260,7 +4259,7 @@ export interface EnergyPlanContractFullV3 extends EnergyPlanContractV3 {
      * An array of the available billing schedules for this contract. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
      */
     billFrequency: string[];
-};
+}
 
 /**
  * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
@@ -4430,7 +4429,7 @@ export interface EnergyPlanControlledLoadV2 {
       /**
        * Array of controlled load rates in order of usage volume
        */
-      rates: {
+      rates: Array<{
         /**
          * The measurement unit of rate. Assumed to be KWH if absent
          */
@@ -4443,7 +4442,7 @@ export interface EnergyPlanControlledLoadV2 {
          * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
          */
         volume?: number;
-      }[];
+      }>;
     };
     /**
      * Optional start date of the application of the controlled load rate
@@ -4452,7 +4451,7 @@ export interface EnergyPlanControlledLoadV2 {
     /**
      * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
      */
-    timeOfUseRates?: {
+    timeOfUseRates?: Array<{
       /**
        * The daily supply charge (exclusive of GST) for this controlled load tier
        */
@@ -4472,7 +4471,7 @@ export interface EnergyPlanControlledLoadV2 {
       /**
        * Array of controlled load rates in order of usage volume
        */
-      rates: {
+      rates: Array<{
         /**
          * The measurement unit of rate. Assumed to be KWH if absent
          */
@@ -4485,11 +4484,11 @@ export interface EnergyPlanControlledLoadV2 {
          * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
          */
         volume?: number;
-      }[];
+      }>;
       /**
        * Array of times of use.
        */
-      timeOfUse: {
+      timeOfUse: Array<{
         /**
          * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
          */
@@ -4501,7 +4500,7 @@ export interface EnergyPlanControlledLoadV2 {
         /**
          * The days that the rate applies to
          */
-        days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
+        days?: Array<("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")>;
         /**
          * The end of the time period per day for which the controlled load rate applies. Required if startTime provided.
          *
@@ -4514,20 +4513,20 @@ export interface EnergyPlanControlledLoadV2 {
          * Formatted according to [ISO 8601 Times](https://en.wikipedia.org/wiki/ISO_8601#Times). If the time is provided without a UTC offset, the time zone will be determined by the value of EnergyPlanContract.timeZone.
          */
         startTime?: string;
-      }[];
+      }>;
       /**
        * The type of usage that the rate applies to
        */
       type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SOLAR_SPONGE";
-    }[];
-};
+    }>;
+}
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyPlanDetail extends EnergyPlan {
     /**
      * Charges for metering included in the plan
      */
-    meteringCharges?: {
+    meteringCharges?: Array<{
         /**
          * Display name of the charge
          */
@@ -4549,7 +4548,7 @@ export interface EnergyPlanDetail extends EnergyPlan {
          */
         period?: string;
         [k: string]: unknown;
-    };
+    }>;
     /**
      * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
      */
@@ -4566,7 +4565,7 @@ export interface EnergyPlanDetailV2 extends EnergyPlan {
     /**
      * Charges for metering included in the plan
      */
-    meteringCharges?: {
+    meteringCharges?: Array<{
         /**
          * Display name of the charge
          */
@@ -4588,7 +4587,7 @@ export interface EnergyPlanDetailV2 extends EnergyPlan {
          */
         period?: string;
         [k: string]: unknown;
-    };
+    }>;
     /**
      * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
      */
@@ -4604,7 +4603,7 @@ export interface EnergyPlanDetailV3 extends EnergyPlan  {
     /**
      * Charges for metering included in the plan
      */
-    meteringCharges?: {
+    meteringCharges?: Array<{
       /**
        * Display name of the charge
        */
@@ -4626,7 +4625,7 @@ export interface EnergyPlanDetailV3 extends EnergyPlan  {
        */
       period?: string;
       [k: string]: unknown;
-    }[];
+    }>;
     /**
      * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
      */
@@ -4636,7 +4635,7 @@ export interface EnergyPlanDetailV3 extends EnergyPlan  {
      */
     electricityContract?: EnergyPlanContractFullV3;
     [k: string]: unknown;
-};
+}
 
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
@@ -4906,6 +4905,17 @@ export interface EnergyPlanResponse {
     [k: string]: unknown;
 }
 
+export interface EnergyPlanResponseV2 {
+    data: EnergyPlanDetailV2;
+    links: Links;
+    meta?: Meta;
+}
+
+export interface EnergyPlanResponseV3 {
+    data: EnergyPlanDetailV3;
+    links: Links;
+    meta?: Meta;
+  }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 /**
@@ -5093,7 +5103,7 @@ export interface EnergyPlanSolarFeedInTariffV3 {
       /**
        * Array of feed in rates
        */
-      rates: {
+      rates: Array<{
         /**
          * The measurement unit of rate. Assumed to be KWH if absent
          */
@@ -5107,7 +5117,7 @@ export interface EnergyPlanSolarFeedInTariffV3 {
          */
         volume?: number;
         [k: string]: unknown;
-      }[];
+      }>;
       [k: string]: unknown;
     };
     /**
@@ -5121,7 +5131,7 @@ export interface EnergyPlanSolarFeedInTariffV3 {
     /**
      * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
      */
-    timeVaryingTariffs?: {
+    timeVaryingTariffs?: Array<{
       /**
        * Display name of the tariff
        */
@@ -5133,7 +5143,7 @@ export interface EnergyPlanSolarFeedInTariffV3 {
       /**
        * Array of feed in rates
        */
-      rates?: {
+      rates?: Array<{
         /**
          * The measurement unit of rate. Assumed to be KWH if absent
          */
@@ -5147,15 +5157,15 @@ export interface EnergyPlanSolarFeedInTariffV3 {
          */
         volume?: number;
         [k: string]: unknown;
-      }[];
+      }>;
       /**
        * Array of time periods for which this tariff is applicable
        */
-      timeVariations: {
+      timeVariations: Array<{
         /**
          * The days that the tariff applies to. At least one entry required
          */
-        days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
+        days: Array<("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")>;
         /**
          * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight).
          *
@@ -5169,15 +5179,15 @@ export interface EnergyPlanSolarFeedInTariffV3 {
          */
         startTime?: string;
         [k: string]: unknown;
-      }[];
+      }>;
       /**
        * The type of the charging time period. If absent applies to all periods
        */
       type?: "PEAK" | "OFF_PEAK" | "SHOULDER";
       [k: string]: unknown;
-    }[];
+    }>;
     [k: string]: unknown;
-  };
+}
 
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
@@ -5368,7 +5378,7 @@ export interface EnergyPlanTariffPeriodV2 {
     /**
      * Array representing banded daily supply charge rates.  Mandatory if dailySupplyChargeType is BAND
      */
-    bandedDailySupplyCharges?: {
+    bandedDailySupplyCharges?: Array<{
       /**
        * The measurement unit of rate. Assumed to be DAYS if absent
        */
@@ -5382,7 +5392,7 @@ export interface EnergyPlanTariffPeriodV2 {
        */
       volume?: number;
       [k: string]: unknown;
-    }[];
+    }>;
     /**
      * The amount of access charge for the tariff period, in dollars per day exclusive of GST. Mandatory if dailySupplyChargeType is SINGLE
      */
@@ -5394,7 +5404,7 @@ export interface EnergyPlanTariffPeriodV2 {
     /**
      * Array of demand charges.  Required if rateBlockUType is demandCharges
      */
-    demandCharges?: {
+    demandCharges?: Array<{
       /**
        * The charge amount per  measure unit exclusive of GST
        */
@@ -5406,7 +5416,7 @@ export interface EnergyPlanTariffPeriodV2 {
       /**
        * The days that the demand tariff applies to
        */
-      days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
+      days?: Array<("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")>;
       /**
        * Description of the charge
        */
@@ -5444,7 +5454,7 @@ export interface EnergyPlanTariffPeriodV2 {
        */
       startTime: string;
       [k: string]: unknown;
-    }[];
+    }>;
     /**
      * The name of the tariff period
      */
@@ -5480,7 +5490,7 @@ export interface EnergyPlanTariffPeriodV2 {
       /**
        * Array of controlled load rates in order of usage volume
        */
-      rates: {
+      rates: Array<{
         /**
          * The measurement unit of rate. Assumed to be KWH if absent
          */
@@ -5494,7 +5504,7 @@ export interface EnergyPlanTariffPeriodV2 {
          */
         volume?: number;
         [k: string]: unknown;
-      }[];
+      }>;
       [k: string]: unknown;
     };
     /**
@@ -5504,7 +5514,7 @@ export interface EnergyPlanTariffPeriodV2 {
     /**
      * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
      */
-    timeOfUseRates?: {
+    timeOfUseRates?: Array<{
       /**
        * Description of the rate
        */
@@ -5520,7 +5530,7 @@ export interface EnergyPlanTariffPeriodV2 {
       /**
        * Array of controlled load rates in order of usage volume
        */
-      rates: {
+      rates: Array<{
         /**
          * The measurement unit of rate. Assumed to be KWH if absent
          */
@@ -5534,15 +5544,15 @@ export interface EnergyPlanTariffPeriodV2 {
          */
         volume?: number;
         [k: string]: unknown;
-      }[];
+      }>;
       /**
        * Array of times of use
        */
-      timeOfUse: {
+      timeOfUse: Array<{
         /**
          * The days that the rate applies to
          */
-        days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
+        days: Array<("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")>;
         /**
          * End of the period.
          *
@@ -5556,13 +5566,13 @@ export interface EnergyPlanTariffPeriodV2 {
          */
         startTime: string;
         [k: string]: unknown;
-      }[];
+      }>;
       /**
        * The type of usage that the rate applies to
        */
       type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SHOULDER1" | "SHOULDER2";
       [k: string]: unknown;
-    }[];
+    }>;
     /**
      * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
      */
@@ -5572,7 +5582,7 @@ export interface EnergyPlanTariffPeriodV2 {
      */
     type?: "ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER";
     [k: string]: unknown;
-  };
+}
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyServicePoint {

--- a/types/consumer-data-standards/energy/index.d.ts
+++ b/types/consumer-data-standards/energy/index.d.ts
@@ -316,6 +316,11 @@ export interface EnergyAccountDetailResponseV3 {
     meta: Meta;
     [k: string]: unknown;
 }
+export interface EnergyAccountDetailResponseV4 {
+  data: EnergyAccountDetailV4;
+  links: Links;
+  meta?: Meta;
+}
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyAccountDetailV2 extends EnergyAccountBaseV2 {
@@ -502,11 +507,15 @@ export interface EnergyAccountDetailV2 extends EnergyAccountBaseV2 {
                              */
                             days?: Array<"SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS">;
                             /**
-                             * The end of the time period per day for which the controlled load rate applies. Required if startTime provided
+       * The end of the time period per day for which the controlled load rate applies. Required if startTime provided.
+       *
+       * Formatted according to [ISO 8601 Times](https://en.wikipedia.org/wiki/ISO_8601#Times). If the time is provided without a UTC offset, the time zone will be determined by the value of EnergyPlanContract.timeZone.
                              */
                             endTime?: string;
                             /**
-                             * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided
+       * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided.
+       *
+       * Formatted according to [ISO 8601 Times](https://en.wikipedia.org/wiki/ISO_8601#Times). If the time is provided without a UTC offset, the time zone will be determined by the value of EnergyPlanContract.timeZone.
                              */
                             startTime?: string;
                             [k: string]: unknown;
@@ -1843,6 +1852,71 @@ export interface EnergyAccountDetailV3 extends EnergyAccountBaseV2 {
     }>;
     [k: string]: unknown;
 }
+
+
+export interface EnergyAccountDetailV4 extends EnergyAccountBaseV2 {
+    /**
+     * The array of plans containing service points and associated plan details
+     */
+    plans: {
+      /**
+       * Optional display name for the plan provided by the customer to help differentiate multiple plans
+       */
+      nickname?: string;
+      /**
+       * An array of servicePointIds, representing NMIs, that this account is linked to
+       */
+      servicePointIds: string[];
+      /**
+       * Mandatory if openStatus is OPEN
+       */
+      planOverview?: {
+        /**
+         * The name of the plan if one exists
+         */
+        displayName?: string;
+        /**
+         * The start date of the applicability of this plan
+         */
+        startDate: string;
+        /**
+         * The end date of the applicability of this plan
+         */
+        endDate?: string;
+      };
+      /**
+       * Detail on the plan applicable to this account. Mandatory if openStatus is OPEN
+       */
+      planDetail?: {
+        [k: string]: unknown;
+      };
+      /**
+       * An array of additional contacts that are authorised to act on this account
+       */
+      authorisedContacts?: {
+        /**
+         * For people with single names this field need not be present. The single name should be in the lastName field
+         */
+        firstName?: string;
+        /**
+         * For people with single names the single name should be in this field
+         */
+        lastName: string;
+        /**
+         * Field is mandatory but array may be empty
+         */
+        middleNames?: string[];
+        /**
+         * Also known as title or salutation. The prefix to the name (e.g. Mr, Mrs, Ms, Miss, Sir, etc)
+         */
+        prefix?: string;
+        /**
+         * Used for a trailing suffix to the name (e.g. Jr)
+         */
+        suffix?: string;
+      }[];
+    }[];
+  };
 
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
@@ -4045,6 +4119,61 @@ export interface EnergyPlanContractV2 {
     variation?: string | null;
     [k: string]: unknown;
 }
+
+export interface EnergyPlanContractV3 {
+    /**
+     * Free text field containing additional information of the fees for this contract
+     */
+    additionalFeeInformation?: string | null;
+    controlledLoad?: EnergyPlanControlledLoadV2[];
+    discounts?: EnergyPlanDiscounts;
+    eligibility?: EnergyPlanEligibility;
+    fees?: EnergyPlanFees;
+    greenPowerCharges?: EnergyPlanGreenPowerCharges;
+    incentives?: EnergyPlanIncentives;
+    /**
+     * Describes intrinsic green power for the plan.  If present then the plan includes a percentage of green power in the base plan. Should not be present for gas contracts
+     */
+    intrinsicGreenPower?: {
+      /**
+       * Percentage of green power intrinsically included in the plan
+       */
+      greenPercentage: string;
+    } | null;
+    /**
+     * Flag indicating whether prices are fixed or variable
+     */
+    isFixed: boolean;
+    /**
+     * Free text field that describes what will occur on or prior to expiry of the fixed contract term or benefit period
+     */
+    onExpiryDescription?: string | null;
+    /**
+     * Payment options for this contract
+     */
+    paymentOption: ("PAPER_BILL" | "CREDIT_CARD" | "DIRECT_DEBIT" | "BPAY" | "OTHER")[];
+    /**
+     * The pricing model for the contract.  Contracts for gas must use SINGLE_RATE.  Note that the detail for the enumeration values are:<ul><li>**SINGLE_RATE** - all energy usage is charged at a single unit rate no matter when it is consumed. Multiple unit rates may exist that correspond to varying volumes of usage i.e. a ‘block’ or ‘step’ tariff (first 50kWh @ X cents, next 50kWh at Y cents etc.</li><li>**SINGLE_RATE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**TIME_OF_USE** - energy usage is charged at unit rates that vary dependent on time of day and day of week that the energy is consumed</li><li>**TIME_OF_USE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**FLEXIBLE** - energy usage is charged at unit rates that vary based on external factors</li><li>**FLEXIBLE_CONT_LOAD** - as above, but with an additional, separate unit rate charged for all energy usage from a controlled load i.e. separately metered appliance like hot water service, pool pump etc.</li><li>**QUOTA** - all energy usage is charged at a single fixed rate, up to a specified usage quota/allowance. All excess usage beyond the allowance is then charged at a single unit rate (may not be the best way to explain it but it is essentially a ‘subscription’ or telco style product i.e. $50/month for up to 150kWh included usage</li></ul>
+     */
+    pricingModel:
+      | "SINGLE_RATE"
+      | "SINGLE_RATE_CONT_LOAD"
+      | "TIME_OF_USE"
+      | "TIME_OF_USE_CONT_LOAD"
+      | "FLEXIBLE"
+      | "FLEXIBLE_CONT_LOAD"
+      | "QUOTA";
+    solarFeedInTariff?: EnergyPlanSolarFeedInTariffV3[];
+    tariffPeriod: EnergyPlanTariffPeriodV2[];
+    /**
+     * Required if pricingModel is set to TIME_OF_USE.  Defines the time zone to use for calculation of the time of use thresholds. Defaults to AEST if absent
+     */
+    timeZone?: ("LOCAL" | "AEST") | null;
+    /**
+     * Free text description of price variation policy and conditions for the contract.  Mandatory if `isFixed` is false
+     */
+    variation?: string | null;
+}
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyPlanContractFull extends EnergyPlanContractV2 {
@@ -4105,6 +4234,33 @@ export interface EnergyPlanContractFullV2 extends EnergyPlanContractV2 {
     [k: string]: unknown;
 }
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
+
+export interface EnergyPlanContractFullV3 extends EnergyPlanContractV3 {
+    /**
+     * The term for the contract.  If absent assumes no specified term
+     */
+    termType?: "1_YEAR" | "2_YEAR" | "3_YEAR" | "4_YEAR" | "5_YEAR" | "ONGOING" | "OTHER";
+    /**
+     * Description of the benefit period.  Should only be present if termType has the value ONGOING
+     */
+    benefitPeriod?: string;
+    /**
+     * Free text description of the terms for the contract
+     */
+    terms?: string;
+    /**
+     * An array of the meter types that this contract is available for
+     */
+    meterTypes?: string[];
+    /**
+     * Number of days in the cooling off period for the contract.  Mandatory for plans with type of MARKET
+     */
+    coolingOffDays?: number;
+    /**
+     * An array of the available billing schedules for this contract. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+     */
+    billFrequency: string[];
+};
 
 /**
  * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
@@ -4234,6 +4390,137 @@ export interface EnergyPlanControlledLoad {
     }>;
     [k: string]: unknown;
 }
+
+/**
+ * Required if pricing model is SINGLE_RATE_CONT_LOAD or TIME_OF_USE_CONT_LOAD or FLEXIBLE_CONT_LOAD
+ */
+export interface EnergyPlanControlledLoadV2 {
+    /**
+     * A display name for the controlled load
+     */
+    displayName: string;
+    /**
+     * Optional end date of the application of the controlled load rate
+     */
+    endDate?: string;
+    /**
+     * Specifies the type of controlloed load rate
+     */
+    rateBlockUType: "singleRate" | "timeOfUseRates";
+    /**
+     * Object representing a single controlled load rate.  Required if rateBlockUType is singleRate
+     */
+    singleRate?: {
+      /**
+       * The daily supply charge (exclusive of GST) for this controlled load tier
+       */
+      dailySupplyCharge?: string;
+      /**
+       * Description of the controlled load rate
+       */
+      description?: string;
+      /**
+       * Display name of the controlled load rate
+       */
+      displayName: string;
+      /**
+       * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax). Defaults to P1Y if absent
+       */
+      period?: string;
+      /**
+       * Array of controlled load rates in order of usage volume
+       */
+      rates: {
+        /**
+         * The measurement unit of rate. Assumed to be KWH if absent
+         */
+        measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
+        /**
+         * Unit price of usage per  measure unit (exclusive of GST)
+         */
+        unitPrice: string;
+        /**
+         * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+         */
+        volume?: number;
+      }[];
+    };
+    /**
+     * Optional start date of the application of the controlled load rate
+     */
+    startDate?: string;
+    /**
+     * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+     */
+    timeOfUseRates?: {
+      /**
+       * The daily supply charge (exclusive of GST) for this controlled load tier
+       */
+      dailySupplyCharge?: string;
+      /**
+       * Description of the controlled load rate
+       */
+      description?: string;
+      /**
+       * Display name of the controlled load rate
+       */
+      displayName: string;
+      /**
+       * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax). Defaults to P1Y if absent
+       */
+      period?: string;
+      /**
+       * Array of controlled load rates in order of usage volume
+       */
+      rates: {
+        /**
+         * The measurement unit of rate. Assumed to be KWH if absent
+         */
+        measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
+        /**
+         * Unit price of usage per  measure unit (exclusive of GST)
+         */
+        unitPrice: string;
+        /**
+         * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+         */
+        volume?: number;
+      }[];
+      /**
+       * Array of times of use.
+       */
+      timeOfUse: {
+        /**
+         * Display text providing more information on the contrlled load, for e.g. controlled load availability if specific day/time is not known. Required if startTime and endTime absent or if additionalInfoUri provided
+         */
+        additionalInfo?: string;
+        /**
+         * Optional link to additional information regarding the controlled load
+         */
+        additionalInfoUri?: string;
+        /**
+         * The days that the rate applies to
+         */
+        days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
+        /**
+         * The end of the time period per day for which the controlled load rate applies. Required if startTime provided.
+         *
+         * Formatted according to [ISO 8601 Times](https://en.wikipedia.org/wiki/ISO_8601#Times). If the time is provided without a UTC offset, the time zone will be determined by the value of EnergyPlanContract.timeZone.
+         */
+        endTime?: string;
+        /**
+         * The beginning of the time period per day for which the controlled load rate applies. Required if endTime provided.
+         *
+         * Formatted according to [ISO 8601 Times](https://en.wikipedia.org/wiki/ISO_8601#Times). If the time is provided without a UTC offset, the time zone will be determined by the value of EnergyPlanContract.timeZone.
+         */
+        startTime?: string;
+      }[];
+      /**
+       * The type of usage that the rate applies to
+       */
+      type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SOLAR_SPONGE";
+    }[];
+};
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyPlanDetail extends EnergyPlan {
@@ -4312,6 +4599,44 @@ export interface EnergyPlanDetailV2 extends EnergyPlan {
     electricityContract?: EnergyPlanContractFullV2;
     [k: string]: unknown;
 }
+
+export interface EnergyPlanDetailV3 extends EnergyPlan  {
+    /**
+     * Charges for metering included in the plan
+     */
+    meteringCharges?: {
+      /**
+       * Display name of the charge
+       */
+      displayName: string;
+      /**
+       * Description of the charge
+       */
+      description?: string;
+      /**
+       * Minimum value of the charge if the charge is a range or the absolute value of the charge if no range is specified
+       */
+      minimumValue: string;
+      /**
+       * The upper limit of the charge if the charge could occur in a range
+       */
+      maximumValue?: string;
+      /**
+       * The charges that occur on a schedule indicates the frequency. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+       */
+      period?: string;
+      [k: string]: unknown;
+    }[];
+    /**
+     * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to GAS or DUAL
+     */
+    gasContract?: EnergyPlanContractFullV3;
+    /**
+     * The details of the terms for the supply of electricity under this plan.  Is mandatory if fuelType is set to ELECTRICITY or DUAL
+     */
+    electricityContract?: EnergyPlanContractFullV3;
+    [k: string]: unknown;
+};
 
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
@@ -4732,6 +5057,128 @@ export interface EnergyPlanSolarFeedInTariffV2 {
     };
     [k: string]: unknown;
 }
+
+/**
+ * Array of feed in tariffs for solar power
+ */
+export interface EnergyPlanSolarFeedInTariffV3 {
+    /**
+     * A description of the tariff
+     */
+    description?: string;
+    /**
+     * The name of the tariff
+     */
+    displayName: string;
+    /**
+     * The end date of the application of the feed in tariff
+     */
+    endDate?: string;
+    /**
+     * The type of the payer
+     */
+    payerType: "GOVERNMENT" | "RETAILER";
+    /**
+     * The applicable scheme
+     */
+    scheme: "PREMIUM" | "CURRENT" | "VARIABLE" | "OTHER";
+    /**
+     * Represents a constant tariff.  Mandatory if tariffUType is set to singleTariff
+     */
+    singleTariff?: {
+      /**
+       * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax). Defaults to P1Y if absent
+       */
+      period?: string;
+      /**
+       * Array of feed in rates
+       */
+      rates: {
+        /**
+         * The measurement unit of rate. Assumed to be KWH if absent
+         */
+        measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
+        /**
+         * Unit price of usage per measure unit (exclusive of GST)
+         */
+        unitPrice: string;
+        /**
+         * Volume that this rate applies to. Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+         */
+        volume?: number;
+        [k: string]: unknown;
+      }[];
+      [k: string]: unknown;
+    };
+    /**
+     * The start date of the application of the feed in tariff
+     */
+    startDate?: string;
+    /**
+     * The type of the payer
+     */
+    tariffUType: "singleTariff" | "timeVaryingTariffs";
+    /**
+     * Represents a tariff based on time.  Mandatory if tariffUType is set to timeVaryingTariffs
+     */
+    timeVaryingTariffs?: {
+      /**
+       * Display name of the tariff
+       */
+      displayName: string;
+      /**
+       * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax). Defaults to P1Y if absent
+       */
+      period?: string;
+      /**
+       * Array of feed in rates
+       */
+      rates?: {
+        /**
+         * The measurement unit of rate. Assumed to be KWH if absent
+         */
+        measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
+        /**
+         * Unit price of usage per measure unit (exclusive of GST)
+         */
+        unitPrice: string;
+        /**
+         * Volume that this rate applies to. Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+         */
+        volume?: number;
+        [k: string]: unknown;
+      }[];
+      /**
+       * Array of time periods for which this tariff is applicable
+       */
+      timeVariations: {
+        /**
+         * The days that the tariff applies to. At least one entry required
+         */
+        days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
+        /**
+         * The end of the time period per day for which the tariff applies.  If absent assumes end of day (ie. one second before midnight).
+         *
+         * Formatted according to [ISO 8601 Times](https://en.wikipedia.org/wiki/ISO_8601#Times). If the time is provided without a UTC offset, the time zone will be determined by the value of EnergyPlanContract.timeZone.
+         */
+        endTime?: string;
+        /**
+         * The beginning of the time period per day for which the tariff applies.  If absent assumes start of day (ie. midnight).
+         *
+         * Formatted according to [ISO 8601 Times](https://en.wikipedia.org/wiki/ISO_8601#Times). If the time is provided without a UTC offset, the time zone will be determined by the value of EnergyPlanContract.timeZone.
+         */
+        startTime?: string;
+        [k: string]: unknown;
+      }[];
+      /**
+       * The type of the charging time period. If absent applies to all periods
+       */
+      type?: "PEAK" | "OFF_PEAK" | "SHOULDER";
+      [k: string]: unknown;
+    }[];
+    [k: string]: unknown;
+  };
+
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 /**
@@ -4913,6 +5360,219 @@ export interface EnergyPlanTariffPeriod {
     type?: "ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER";
     [k: string]: unknown;
 }
+
+/**
+ * Array of tariff periods
+ */
+export interface EnergyPlanTariffPeriodV2 {
+    /**
+     * Array representing banded daily supply charge rates.  Mandatory if dailySupplyChargeType is BAND
+     */
+    bandedDailySupplyCharges?: {
+      /**
+       * The measurement unit of rate. Assumed to be DAYS if absent
+       */
+      measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
+      /**
+       * The amount of daily supply charge for the band, in dollars per day exclusive of GST
+       */
+      unitPrice: string;
+      /**
+       * Volume the charge applies to
+       */
+      volume?: number;
+      [k: string]: unknown;
+    }[];
+    /**
+     * The amount of access charge for the tariff period, in dollars per day exclusive of GST. Mandatory if dailySupplyChargeType is SINGLE
+     */
+    dailySupplyCharge?: string;
+    /**
+     * Specifies if daily supply charge is single or banded. Default value is SINGLE if field not provided
+     */
+    dailySupplyChargeType?: "SINGLE" | "BAND";
+    /**
+     * Array of demand charges.  Required if rateBlockUType is demandCharges
+     */
+    demandCharges?: {
+      /**
+       * The charge amount per  measure unit exclusive of GST
+       */
+      amount: string;
+      /**
+       * Charge period for the demand tariff
+       */
+      chargePeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
+      /**
+       * The days that the demand tariff applies to
+       */
+      days?: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
+      /**
+       * Description of the charge
+       */
+      description?: string;
+      /**
+       * Display name of the charge
+       */
+      displayName: string;
+      /**
+       * End of the period.
+       *
+       * Formatted according to [ISO 8601 Times](https://en.wikipedia.org/wiki/ISO_8601#Times). If the time is provided without a UTC offset, the time zone will be determined by the value of EnergyPlanContract.timeZone.
+       */
+      endTime: string;
+      /**
+       * Maximum demand for this demand tariff in kW.  If present, must be higher than the value of the minDemand field
+       */
+      maxDemand?: string;
+      /**
+       * The measurement unit of charge amount. Assumed to be KWH if absent
+       */
+      measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
+      /**
+       * Application period for the demand tariff
+       */
+      measurementPeriod: "DAY" | "MONTH" | "TARIFF_PERIOD";
+      /**
+       * Minimum demand for this demand tariff in kW.  If absent then 0 is assumed
+       */
+      minDemand?: string;
+      /**
+       * Start of the period.
+       *
+       * Formatted according to [ISO 8601 Times](https://en.wikipedia.org/wiki/ISO_8601#Times). If the time is provided without a UTC offset, the time zone will be determined by the value of EnergyPlanContract.timeZone.
+       */
+      startTime: string;
+      [k: string]: unknown;
+    }[];
+    /**
+     * The name of the tariff period
+     */
+    displayName: string;
+    /**
+     * The end date of the tariff period in a calendar year.  Formatted in mm-dd format
+     */
+    endDate: string;
+    /**
+     * Specifies the type of rate applicable to this tariff period
+     */
+    rateBlockUType: "singleRate" | "timeOfUseRates" | "demandCharges";
+    /**
+     * Object representing a single rate.  Required if rateBlockUType is singleRate
+     */
+    singleRate?: {
+      /**
+       * Description of the rate
+       */
+      description?: string;
+      /**
+       * Display name of the rate
+       */
+      displayName: string;
+      /**
+       * The block rate (unit price) for any usage above the included fixed usage, in dollars per kWh inclusive of GST.  Only required if pricingModel field is ‘QUOTA’
+       */
+      generalUnitPrice?: string;
+      /**
+       * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax)
+       */
+      period?: string;
+      /**
+       * Array of controlled load rates in order of usage volume
+       */
+      rates: {
+        /**
+         * The measurement unit of rate. Assumed to be KWH if absent
+         */
+        measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
+        /**
+         * Unit price of usage per measure unit (exclusive of GST)
+         */
+        unitPrice: string;
+        /**
+         * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+         */
+        volume?: number;
+        [k: string]: unknown;
+      }[];
+      [k: string]: unknown;
+    };
+    /**
+     * The start date of the tariff period in a calendar year.  Formatted in mm-dd format
+     */
+    startDate: string;
+    /**
+     * Array of objects representing time of use rates.  Required if rateBlockUType is timeOfUseRates
+     */
+    timeOfUseRates?: {
+      /**
+       * Description of the rate
+       */
+      description?: string;
+      /**
+       * Display name of the rate
+       */
+      displayName: string;
+      /**
+       * Usage period for which the block rate applies. Formatted according to [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) (excludes recurrence syntax). Defaults to P1Y if absent
+       */
+      period?: string;
+      /**
+       * Array of controlled load rates in order of usage volume
+       */
+      rates: {
+        /**
+         * The measurement unit of rate. Assumed to be KWH if absent
+         */
+        measureUnit?: "KWH" | "KVA" | "KVAR" | "KVARH" | "KW" | "DAYS" | "METER" | "MONTH";
+        /**
+         * Unit price of usage per  measure unit (exclusive of GST)
+         */
+        unitPrice: string;
+        /**
+         * Volume in kWh that this rate applies to.  Only applicable for ‘stepped’ rates where different rates apply for different volumes of usage in a period
+         */
+        volume?: number;
+        [k: string]: unknown;
+      }[];
+      /**
+       * Array of times of use
+       */
+      timeOfUse: {
+        /**
+         * The days that the rate applies to
+         */
+        days: ("SUN" | "MON" | "TUE" | "WED" | "THU" | "FRI" | "SAT" | "PUBLIC_HOLIDAYS")[];
+        /**
+         * End of the period.
+         *
+         * Formatted according to [ISO 8601 Times](https://en.wikipedia.org/wiki/ISO_8601#Times). If the time is provided without a UTC offset, the time zone will be determined by the value of EnergyPlanContract.timeZone.
+         */
+        endTime: string;
+        /**
+         * Start of the period.
+         *
+         * Formatted according to [ISO 8601 Times](https://en.wikipedia.org/wiki/ISO_8601#Times). If the time is provided without a UTC offset, the time zone will be determined by the value of EnergyPlanContract.timeZone.
+         */
+        startTime: string;
+        [k: string]: unknown;
+      }[];
+      /**
+       * The type of usage that the rate applies to
+       */
+      type: "PEAK" | "OFF_PEAK" | "SHOULDER" | "SHOULDER1" | "SHOULDER2";
+      [k: string]: unknown;
+    }[];
+    /**
+     * Specifies the charge specific time zone for calculation of the time of use thresholds. If absent, timezone value in EnergyPlanContract is assumed.
+     */
+    timeZone?: "LOCAL" | "AEST";
+    /**
+     * Type of charge. Assumed to be other if absent
+     */
+    type?: "ENVIRONMENTAL" | "REGULATED" | "NETWORK" | "METERING" | "RETAIL_SERVICE" | "RCTI" | "OTHER";
+    [k: string]: unknown;
+  };
 /* These are the schema definitions stipulated by the Data Standards Body for the energy api. */
 
 export interface EnergyServicePoint {


### PR DESCRIPTION
Updated the type definitions to align with version 1.31.0 version of the published standard

**Admin:** 
New defintions for PerformancMetrics scemas

**Banking:**

- some changes to existing scema documentation

**Energy:**
New defintions for 

- EnergyAccountDetailV4
- EnergyAccountDetailResonseV4
- EnergyPlanContractV3
- EnergyPlanContractFullV3
- EnergyPlanControlledLoadV2
- EnergyPlanResponseV3
- EnergyPlanSolarFeedInTariffV3
- EnergyPlanTariffPeriodV2



